### PR TITLE
remove extra TwitchLib from dotnet build path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dotnet: 2.0.0
 dist: trusty
 script:
  - dotnet restore
- - dotnet build /home/travis/build/TwitchLib/TwitchLib/TwitchLib.Client/TwitchLib.Client/TwitchLib.Client.csproj --framework netstandard2.0
+ - dotnet build /home/travis/build/TwitchLib/TwitchLib.Client/TwitchLib.Client/TwitchLib.Client.csproj --framework netstandard2.0
 
 addons:
   apt:


### PR DESCRIPTION
In the future we should probably change this to use relative paths, but this should fix the build issue