### PR TITLE
GetChannelModerators method moved to extension.

### DIFF
--- a/TwitchLib.Client/Extensions/GetChannelModeratorsExt.cs
+++ b/TwitchLib.Client/Extensions/GetChannelModeratorsExt.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using TwitchLib.Client.Interfaces;
+using TwitchLib.Client.Models;
+
+namespace TwitchLib.Client.Extensions
+{
+    /// <summary>Extension for implementing Commercial functionality in TwitchClient.</summary>
+    public static class GetChannelModeratorsExt
+    {
+        /// <summary>
+        /// Sends command to get list of moderators from Twitch.
+        /// </summary>
+        /// <param name="channel">JoinedChannel representation of the channel to send the command to get moderators to.</param>
+        /// <param name="client">Client reference used to identify extension.</param>
+        public static void GetChannelModerators(this ITwitchClient client, JoinedChannel channel)
+        {
+            client.SendMessage(channel, ".mods");
+        }
+
+        /// <summary>
+        /// Sends command to get list of moderators from Twitch.
+        /// </summary>
+        /// <param name="channel">String representation of the channel to send the command to get moderators to.</param>
+        /// <param name="client">Client reference used to identify extension.</param>
+        public static void GetChannelModerators(this ITwitchClient client, string channel)
+        {
+            client.SendMessage(channel, ".mods");
+        }
+    }
+}

--- a/TwitchLib.Client/Interfaces/ITwitchClient.cs
+++ b/TwitchLib.Client/Interfaces/ITwitchClient.cs
@@ -79,9 +79,6 @@ namespace TwitchLib.Client.Interfaces
         void LeaveChannel(string channel);
         void LeaveRoom(string channelId, string roomId);
 
-        void GetChannelModerators(JoinedChannel channel);
-        void GetChannelModerators(string channel);
-
         void OnReadLineTest(string rawIrc);
 
         void SendMessage(JoinedChannel channel, string message, bool dryRun = false);

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -621,30 +621,6 @@ namespace TwitchLib.Client
             LeaveChannel(channel.Channel);
         }
 
-        /// <summary>
-        /// Sends a request to get channel moderators. You MUST listen to OnModeratorsReceived event./>.
-        /// </summary>
-        /// <param name="channel">JoinedChannel object to designate which channel to send request to.</param>
-        public void GetChannelModerators(JoinedChannel channel)
-        {
-            if (!IsInitialized) HandleNotInitialized();
-            if (OnModeratorsReceived == null)
-                Log("[GetChannelModerators] You are not listening to OnModeratorsReceived. The response to this message will not be handled.");
-            SendMessage(channel, "/mods");
-        }
-
-        /// <summary>
-        /// Sends a request to get channel moderators. You MUST listen to OnModeratorsReceived event./>.
-        /// </summary>
-        /// <param name="channel">String representing channel to designate which channel to send request to.</param>
-        public void GetChannelModerators(string channel)
-        {
-            if (!IsInitialized) HandleNotInitialized();
-            var joinedChannel = GetJoinedChannel(channel);
-            if (joinedChannel != null)
-                GetChannelModerators(joinedChannel);
-        }
-
         #endregion
 
         /// <summary>


### PR DESCRIPTION
The big (and controversial?) change here is that this was removed because of the nature of extensions:
```csharp
if (OnModeratorsReceived == null)
               Log("[GetChannelModerators] You are not listening to OnModeratorsReceived. The response to this message will not be handled.");
```

This was originally an exception, but because exceptions are not ideal, it was moved to a log message. Now, because extension methods don't normally have access to events, we also can't do the above code. I'm not entirely convinced the above code is absolutely necessary tbh. Additionally, the logging needs work, and that was kind of half-assed.

The goal of this PR is to move GetChannelModerators (ie "/mods") command to an extension like the other commands.

discuss