### PR TITLE
Fix OnFailureToReceiveJoinConfirmation event

### DIFF
--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -738,8 +738,12 @@ namespace TwitchLib.Client
                     }
                 }
             }
-            if (_awaitingJoins.Any())
+            else
+            {
                 _joinTimer.Stop();
+                _currentlyJoiningChannels = false;
+                QueueingJoinCheck();
+            }
         }
 
         #endregion


### PR DESCRIPTION
The `OnFailureToReceiveJoinConfirmation` event would never fire because `_joinTimer` is always stopped after it first elapses.

Also need to reset `_currentlyJoiningChannels` to false and call `QueuingJoinCheck()` here so the client is able to join new channels afterwards.