### PR TITLE
Detect suspended channel, resume join queue. Related to #43

### DIFF
--- a/TwitchLib.Client/Exceptions/FailureToReceiveJoinConfirmationException.cs
+++ b/TwitchLib.Client/Exceptions/FailureToReceiveJoinConfirmationException.cs
@@ -4,11 +4,14 @@
     {
         /// <summary>Exception representing failure of client to receive JOIN confirmation.</summary>
         public string Channel { get; protected set; }
+        /// <summary>Extra details regarding this exception (not always set)</summary>
+        public string Details { get; protected set; }
 
         /// <summary>Exception construtor.</summary>
-        public FailureToReceiveJoinConfirmationException(string channel)
+        public FailureToReceiveJoinConfirmationException(string channel, string details = null)
         {
             Channel = channel;
+            Details = details;
         }
     }
 }

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -907,6 +907,14 @@ namespace TwitchLib.Client
                 case MsgIds.RaidNoticeMature:
                     OnRaidedChannelIsMatureAudience?.Invoke(this, null);
                     break;
+                case MsgIds.MsgChannelSuspended:
+                    string channel = ircMessage.ToString().Split('#')[1].Split(' ')[0];
+                    _awaitingJoins.RemoveAll(x => x.Key.ToLower() == channel);
+                    QueueingJoinCheck();
+                    OnFailureToReceiveJoinConfirmation(this, new OnFailureToReceiveJoinConfirmationArgs {
+                        Exception = new FailureToReceiveJoinConfirmationException(channel, ircMessage.Message)
+                        });
+                    break;
                 default:
                     OnUnaccountedFor?.Invoke(this, new OnUnaccountedForArgs { BotUsername = TwitchUsername, Channel = ircMessage.Channel, Location = "NoticeHandling", RawIRC = ircMessage.ToString() });
                     Log($"Unaccounted for: {ircMessage.ToString()}");

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -908,11 +908,10 @@ namespace TwitchLib.Client
                     OnRaidedChannelIsMatureAudience?.Invoke(this, null);
                     break;
                 case MsgIds.MsgChannelSuspended:
-                    string channel = ircMessage.ToString().Split('#')[1].Split(' ')[0];
-                    _awaitingJoins.RemoveAll(x => x.Key.ToLower() == channel);
+                    _awaitingJoins.RemoveAll(x => x.Key.ToLower() == ircMessage.Channel);
                     QueueingJoinCheck();
                     OnFailureToReceiveJoinConfirmation(this, new OnFailureToReceiveJoinConfirmationArgs {
-                        Exception = new FailureToReceiveJoinConfirmationException(channel, ircMessage.Message)
+                        Exception = new FailureToReceiveJoinConfirmationException(ircMessage.Channel, ircMessage.Message)
                         });
                     break;
                 default:


### PR DESCRIPTION
- detect suspended channel and raise OnFailureToReceiveJoinConfirmation event
- remove channel from awaiting joins
- resume join queue

Related: #43 