### PR TITLE
Expose ChatMessage.Id and some smaller fixes. Related to #44

### DIFF
--- a/TwitchLib.Client/Extensions/EventInvocationExt.cs
+++ b/TwitchLib.Client/Extensions/EventInvocationExt.cs
@@ -43,12 +43,12 @@ namespace TwitchLib.Client.Extensions
         }
 
         public static void InvokeChatCommandsReceived(this TwitchClient client, string botUsername, string userId, string userName, string displayName,
-            string colorHex, Color color, EmoteSet emoteSet, string message, UserType userType, string channel, bool isSubscriber, int subscribedMonthCount,
+            string colorHex, Color color, EmoteSet emoteSet, string message, UserType userType, string channel, string id, bool isSubscriber, int subscribedMonthCount,
             string roomId, bool isTurbo, bool isModerator, bool isMe, bool isBroadcaster, Noisy noisy, string rawIrcMessage, string emoteReplacedMessage,
             List<KeyValuePair<string, string>> badges, CheerBadge cheerBadge, int bits, double bitsInDollars, string commandText, string argumentsAsString,
             List<string> argumentsAsList, char commandIdentifier)
         {
-            var msg = new ChatMessage(botUsername, userId, userName, displayName, colorHex, color, emoteSet, message, userType, channel,
+            var msg = new ChatMessage(botUsername, userId, userName, displayName, colorHex, color, emoteSet, message, userType, channel, id,
                 isSubscriber, subscribedMonthCount, roomId, isTurbo, isModerator, isMe, isBroadcaster, noisy, rawIrcMessage, emoteReplacedMessage,
                 badges, cheerBadge, bits, bitsInDollars);
             var model = new OnChatCommandReceivedArgs()
@@ -175,13 +175,13 @@ namespace TwitchLib.Client.Extensions
         }
 
         public static void InvokeMessageReceived(this TwitchClient client, string botUsername, string userId, string userName, string displayName, string colorHex,
-            Color color, EmoteSet emoteSet, string message, UserType userType, string channel, bool isSubscriber, int subscribedMonthCount, string roomId, bool isTurbo,
+            Color color, EmoteSet emoteSet, string message, UserType userType, string channel, string id, bool isSubscriber, int subscribedMonthCount, string roomId, bool isTurbo,
             bool isModerator, bool isMe, bool isBroadcaster, Noisy noisy, string rawIrcMessage, string emoteReplacedMessage, List<KeyValuePair<string, string>> badges,
             CheerBadge cheerBadge, int bits, double bitsInDollars)
         {
             var model = new OnMessageReceivedArgs()
             {
-                ChatMessage = new ChatMessage(botUsername, userId, userName, displayName, colorHex, color, emoteSet, message, userType, channel, isSubscriber,
+                ChatMessage = new ChatMessage(botUsername, userId, userName, displayName, colorHex, color, emoteSet, message, userType, channel, id, isSubscriber,
                 subscribedMonthCount, roomId, isTurbo, isModerator, isMe, isBroadcaster, noisy, rawIrcMessage, emoteReplacedMessage, badges, cheerBadge, bits,
                 bitsInDollars)
             };

--- a/TwitchLib.Client/Models/ChatMessage.cs
+++ b/TwitchLib.Client/Models/ChatMessage.cs
@@ -42,6 +42,8 @@ namespace TwitchLib.Client.Models
         public string EmoteReplacedMessage { get; }
         /// <summary>Emote Ids that exist in message.</summary>
         public EmoteSet EmoteSet { get; }
+        /// <summary>Unique message identifier assigned by Twitch</summary>
+        public string Id { get; }
         /// <summary>Chat message from broadcaster identifier flag</summary>
         public bool IsBroadcaster { get; }
         /// <summary>Chat message /me identifier flag.</summary>
@@ -134,6 +136,9 @@ namespace TwitchLib.Client.Models
                         break;
                     case Tags.Emotes:
                         _emoteSetStorage = tagValue;
+                        break;
+                    case Tags.Id:
+                        Id = tagValue;
                         break;
                     case Tags.Mod:
                         IsModerator = Helpers.ConvertToBool(tagValue);
@@ -243,7 +248,7 @@ namespace TwitchLib.Client.Models
         }
 
         internal ChatMessage(string botUsername, string userId, string userName, string displayName, string colorHex, Color color, EmoteSet emoteSet,
-            string message, UserType userType, string channel, bool isSubscriber, int subscribedMonthCount, string roomId, bool isTurbo, bool isModerator,
+            string message, UserType userType, string channel, string id, bool isSubscriber, int subscribedMonthCount, string roomId, bool isTurbo, bool isModerator,
             bool isMe, bool isBroadcaster, Noisy noisy, string rawIrcMessage, string emoteReplacedMessage, List<KeyValuePair<string, string>> badges,
             CheerBadge cheerBadge, int bits, double bitsInDollars)
         {
@@ -256,6 +261,7 @@ namespace TwitchLib.Client.Models
             Message = message;
             UserType = userType;
             Channel = channel;
+            Id = id;
             IsSubscriber = isSubscriber;
             SubscribedMonthCount = subscribedMonthCount;
             RoomId = roomId;

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -848,15 +848,14 @@ namespace TwitchLib.Client
             OnMessageReceived?.Invoke(this, new OnMessageReceivedArgs { ChatMessage = chatMessage });
 
             if (_chatCommandIdentifiers != null && _chatCommandIdentifiers.Count != 0 && !string.IsNullOrEmpty(chatMessage.Message))
+            {
                 if (_chatCommandIdentifiers.Contains(chatMessage.Message[0]))
                 {
                     var chatCommand = new ChatCommand(chatMessage);
                     OnChatCommandReceived?.Invoke(this, new OnChatCommandReceivedArgs { Command = chatCommand });
                     return;
                 }
-
-            OnUnaccountedFor?.Invoke(this, new OnUnaccountedForArgs { BotUsername = TwitchUsername, Channel = ircMessage.Channel, Location = "PrivMsgHandling", RawIRC = ircMessage.ToString() });
-            Log($"Unaccounted for: {ircMessage.ToString()}");
+            }
         }
 
         private void HandleNotice(IrcMessage ircMessage)
@@ -909,6 +908,7 @@ namespace TwitchLib.Client
                     break;
                 case MsgIds.MsgChannelSuspended:
                     _awaitingJoins.RemoveAll(x => x.Key.ToLower() == ircMessage.Channel);
+                    _joinedChannelManager.RemoveJoinedChannel(ircMessage.Channel);
                     QueueingJoinCheck();
                     OnFailureToReceiveJoinConfirmation?.Invoke(this, new OnFailureToReceiveJoinConfirmationArgs {
                         Exception = new FailureToReceiveJoinConfirmationException(ircMessage.Channel, ircMessage.Message)


### PR DESCRIPTION
- Exposes ChatMessage Id property
- UnAccountedFor event no longer fires in OnMessageReceived
- Removes suspended channels from joinedchannel list