### PR TITLE
Emote set count zero fix

### DIFF
--- a/TwitchLib.Client.Models/ChatMessage.cs
+++ b/TwitchLib.Client.Models/ChatMessage.cs
@@ -50,8 +50,6 @@ namespace TwitchLib.Client.Models
         /// <summary>Number of months a person has been subbed.</summary>
         public int SubscribedMonthCount { get; }        
 
-        private readonly string _emoteSetStorage;
-
         //Example IRC message: @badges=moderator/1,warcraft/alliance;color=;display-name=Swiftyspiffyv4;emotes=;mod=1;room-id=40876073;subscriber=0;turbo=0;user-id=103325214;user-type=mod :swiftyspiffyv4!swiftyspiffyv4@swiftyspiffyv4.tmi.twitch.tv PRIVMSG #swiftyspiffy :asd
         /// <summary>Constructor for ChatMessage object.</summary>
         /// <param name="botUsername">The username of the bot that received the message.</param>
@@ -112,7 +110,7 @@ namespace TwitchLib.Client.Models
                         DisplayName = tagValue;
                         break;
                     case Tags.Emotes:
-                        _emoteSetStorage = tagValue;
+                        EmoteSet = new EmoteSet(tagValue, Message);
                         break;
                     case Tags.Id:
                         Id = tagValue;
@@ -157,8 +155,6 @@ namespace TwitchLib.Client.Models
                         break;
                 }
             }
-
-            EmoteSet = new EmoteSet(_emoteSetStorage, Message);
 
             if (Message.Length > 0 && (byte)Message[0] == 1 && (byte)Message[Message.Length - 1] == 1)
             {

--- a/TwitchLib.Client.Models/ChatMessage.cs
+++ b/TwitchLib.Client.Models/ChatMessage.cs
@@ -201,6 +201,9 @@ namespace TwitchLib.Client.Models
                 }
             }
 
+            if (EmoteSet == null)
+                EmoteSet = new EmoteSet(null, Message);
+
             // Check if display name was set, and if it wasn't, set it to username
             if (string.IsNullOrEmpty(DisplayName))
                 DisplayName = Username;

--- a/TwitchLib.Client.Models/ChatMessage.cs
+++ b/TwitchLib.Client.Models/ChatMessage.cs
@@ -64,7 +64,6 @@ namespace TwitchLib.Client.Models
             RawIrcMessage = ircMessage.ToString();
             Message = ircMessage.Message;
             _emoteCollection = emoteCollection;
-            EmoteSet = new EmoteSet(_emoteSetStorage, Message);
 
             Username = ircMessage.User;
             Channel = ircMessage.Channel;
@@ -158,6 +157,8 @@ namespace TwitchLib.Client.Models
                         break;
                 }
             }
+
+            EmoteSet = new EmoteSet(_emoteSetStorage, Message);
 
             if (Message.Length > 0 && (byte)Message[0] == 1 && (byte)Message[Message.Length - 1] == 1)
             {

--- a/TwitchLib.Client.Models/WhisperMessage.cs
+++ b/TwitchLib.Client.Models/WhisperMessage.cs
@@ -107,6 +107,9 @@ namespace TwitchLib.Client.Models
                         break;
                 }
             }
+
+            if (EmoteSet == null)
+                EmoteSet = new EmoteSet(null, Message);
         }
     }
 }


### PR DESCRIPTION
Previously the EmoteSet was created before the message was parsed, meaning _emoteSetStorage would always be null, resulting in the EmoteSet being empty, which then again results in the EmoteSet having "EmoteSet.Emotes.Count" being 0.

This is a fix for #405 https://github.com/TwitchLib/TwitchLib/issues/405 

This does raise a question: Why is the instance of EmoteSet not being created in the switch Case, just like in the WhisperMessage? This seems to work just fine (see commit).