### PR TITLE
Extension cleanup

### DIFF
--- a/TwitchLib.Client/Extensions/BanUserExt.cs
+++ b/TwitchLib.Client/Extensions/BanUserExt.cs
@@ -33,18 +33,5 @@ namespace TwitchLib.Client.Extensions
             if (joinedChannel != null)
                 BanUser(client, joinedChannel, viewer, message, dryRun);
         }
-
-        /// <summary>
-        /// Bans a user in chat using the first joined channel
-        /// </summary>
-        /// <param name="viewer">Viewer name to ban</param>
-        /// <param name="message">Message to accompany the ban and show the user.</param>
-        /// <param name="dryRun">Indicates a dryrun (will not send if true)</param>
-        /// <param name="client">Client reference used to identify extension.</param>
-        public static void BanUser(this ITwitchClient client, string viewer, string message = "", bool dryRun = false)
-        {
-            if (client.JoinedChannels.Count > 0)
-                BanUser(client, client.JoinedChannels[0], viewer, message, dryRun);
-        }
     }
 }

--- a/TwitchLib.Client/Extensions/RaidExt.cs
+++ b/TwitchLib.Client/Extensions/RaidExt.cs
@@ -16,5 +16,16 @@ namespace TwitchLib.Client.Extensions
         {
             client.SendMessage(channel, $".raid {channelToRaid}");
         }
+
+        /// <summary>
+        /// Sends command to start raid.
+        /// </summary>
+        /// <param name="channel">String representation of which channel to send the command to.</param>
+        /// <param name="channelToRaid">Channel to begin raid on.</param>
+        /// <param name="client">Client reference used to identify extension.</param>
+        public static void Raid(this ITwitchClient client, string channel, string channelToRaid)
+        {
+            client.SendMessage(channel, $".raid {channelToRaid}");
+        }
     }
 }

--- a/TwitchLib.Client/Extensions/TimeoutUserExt.cs
+++ b/TwitchLib.Client/Extensions/TimeoutUserExt.cs
@@ -37,20 +37,6 @@ namespace TwitchLib.Client.Extensions
             if (joinedChannel != null)
                 TimeoutUser(client, joinedChannel, viewer, duration, message, dryRun);
         }
-
-        /// <summary>
-        /// Timesout a user using the first joined channel.
-        /// </summary>
-        /// <param name="viewer">Viewer name to timeout</param>
-        /// <param name="duration">Duration of the timeout via TimeSpan object</param>
-        /// <param name="message">Message to accompany the timeout and show the user.</param>
-        /// <param name="dryRun">Indicates a dryrun (will not sened if true)</param>
-        /// <param name="client">Client reference used to identify extension.</param>
-        public static void TimeoutUser(this ITwitchClient client, string viewer, TimeSpan duration, string message = "", bool dryRun = false)
-        {
-            if (client.JoinedChannels.Count > 0)
-                TimeoutUser(client, client.JoinedChannels[0], viewer, duration, message, dryRun);
-        }
         #endregion
     }
 }

--- a/TwitchLib.Client/Extensions/UnbanUserExt.cs
+++ b/TwitchLib.Client/Extensions/UnbanUserExt.cs
@@ -31,17 +31,5 @@ namespace TwitchLib.Client.Extensions
             if (joinedChannel != null)
                 UnbanUser(client, joinedChannel, viewer, dryRun);
         }
-
-        /// <summary>
-        /// Unbans a user in chat using first joined channel.
-        /// </summary>
-        /// <param name="viewer">Viewer name to unban</param>
-        /// <param name="dryRun">Indicates a dryrun (will not send if true)</param>
-        /// <param name="client">Client reference used to identify extension.</param>
-        public static void UnbanUser(this ITwitchClient client, string viewer, bool dryRun = false)
-        {
-            if (client.JoinedChannels.Count > 0)
-                UnbanUser(client, client.JoinedChannels[0], viewer, dryRun);
-        }
     }
 }


### PR DESCRIPTION
- TimeoutUser doesn't allow not specifying a channel
- UnbanUser doesn't allow not specifying a channel
- BanUser doesn't allow not specifying a channel
- Raid now allows specifying a channel via string