### PR TITLE
ROOMSTATE fix, adds unimplemented interface method. Related: #78

### DIFF
--- a/TwitchLib.Client.Test/MockIClient.cs
+++ b/TwitchLib.Client.Test/MockIClient.cs
@@ -14,6 +14,8 @@ namespace TwitchLib.Client.Test
 
         public int WhisperQueueLength => throw new NotImplementedException();
 
+        public IClientOptions Options => throw new NotImplementedException();
+
         public event EventHandler<OnConnectedEventArgs> OnConnected;
         public event EventHandler<OnDataEventArgs> OnData;
         public event EventHandler<OnDisconnectedEventArgs> OnDisconnected;
@@ -62,6 +64,26 @@ namespace TwitchLib.Client.Test
         }
 
         public bool SendWhisper(string data)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void MessageThrottled(OnMessageThrottledEventArgs eventArgs)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SendFailed(OnSendFailedEventArgs eventArgs)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Error(OnErrorEventArgs eventArgs)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WhisperThrottled(OnWhisperThrottledEventArgs eventArgs)
         {
             throw new NotImplementedException();
         }

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -1043,7 +1043,9 @@ namespace TwitchLib.Client
 
         private void HandleRoomState(IrcMessage ircMessage)
         {
-            if (ircMessage.Tags.ContainsKey(Tags.SubsOnly) && ircMessage.Tags.ContainsKey(Tags.Slow))
+            // If ROOMSTATE is sent because a mode (subonly/slow/emote/etc) is being toggled, it has two tags: room-id, and the specific mode being toggled
+            // If ROOMSTATE is sent because of a join confirmation, all tags (ie greater than 2) are sent
+            if (ircMessage.Tags.Count > 2)
             {
                 var channel = _awaitingJoins.FirstOrDefault(x => x.Key == ircMessage.Channel);
                 _awaitingJoins.Remove(channel);

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -17,6 +17,7 @@ using TwitchLib.Communication;
 using TwitchLib.Communication.Events;
 using TwitchLib.Client.Enums;
 using TwitchLib.Communication.Interfaces;
+using TwitchLib.Communication.Clients;
 
 namespace TwitchLib.Client
 {

--- a/TwitchLib.Client/TwitchLib.Client.csproj
+++ b/TwitchLib.Client/TwitchLib.Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>TwitchLib.Client</PackageId>
-    <Version>3.0.0</Version>
+    <Version>3.0.3</Version>
     <Description>Client component of TwitchLib. This component allows you to access Twitch chat and whispers, as well as the events that are sent over this connection.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>swiftyspiffy, Prom3theu5, Syzuna, LuckyNoS7evin</Authors>
@@ -17,8 +17,8 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>twitch library irc chat c# csharp api events pubsub net standard 2.0</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion>3.0.0.0</FileVersion>
+    <AssemblyVersion>3.0.3.0</AssemblyVersion>
+    <FileVersion>3.0.3.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Roomstate fix:
- This fix allows the client to correctly detect when it joins a mod only room
- ROOMSTATE fires everytime a client joins a room/channel, as well as when a mode is toggled.
  - When a mode is enabled (ie subonly, emoteonly, r9k, slow, etc), TAGS includes 2 keyvaluepairs. The room-id its for, as well as the mode being toggled (subonly, emoteonly, etc)
  - When a client joins a room, all tags are included (which is more than 2).

In order to build, we need to include the unimplemented interface methods in the mock client