### PR TITLE
Fixes roomstate bug preventing join confirmation for some rooms

### DIFF
--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -17,7 +17,6 @@ using TwitchLib.Communication;
 using TwitchLib.Communication.Events;
 using TwitchLib.Client.Enums;
 using TwitchLib.Communication.Interfaces;
-using TwitchLib.Communication.Clients;
 
 namespace TwitchLib.Client
 {
@@ -1043,7 +1042,9 @@ namespace TwitchLib.Client
 
         private void HandleRoomState(IrcMessage ircMessage)
         {
-            if (ircMessage.Tags.ContainsKey(Tags.SubsOnly) && ircMessage.Tags.ContainsKey(Tags.Slow))
+            // If ROOMSTATE is sent because a mode (subonly/slow/emote/etc) is being toggled, it has two tags: room-id, and the specific mode being toggled
+            // If ROOMSTATE is sent because of a join confirmation, all tags (ie greater than 2) are sent
+            if (ircMessage.Tags.Count > 2)
             {
                 var channel = _awaitingJoins.FirstOrDefault(x => x.Key == ircMessage.Channel);
                 _awaitingJoins.Remove(channel);


### PR DESCRIPTION
Roomstate fix:
- This fix allows the client to correctly detect when it joins a mod only room
- ROOMSTATE fires everytime a client joins a room/channel, as well as when a mode is toggled.
  - When a mode is enabled (ie subonly, emoteonly, r9k, slow, etc), TAGS includes 2 keyvaluepairs. The room-id its for, as well as the mode being toggled (subonly, emoteonly, etc)
  - When a client joins a room, all tags are included (which is more than 2).

Related to: #78 