### PR TITLE
Add TwitchClient Events to Interface

### DIFF
--- a/TwitchLib.Client/Interfaces/ITwitchClient.cs
+++ b/TwitchLib.Client/Interfaces/ITwitchClient.cs
@@ -223,6 +223,27 @@ namespace TwitchLib.Client.Interfaces
         /// Occurs when [on reconnected].
         /// </summary>
         event EventHandler<OnReconnectedEventArgs> OnReconnected;
+        /// <summary>
+        /// Occurs when [on vip received].
+        /// </summary>
+        event EventHandler<OnVIPsReceivedArgs> OnVIPsReceived;
+        /// <summary>
+        /// Occurs when [on community subscription announcement received].
+        /// </summary>
+        event EventHandler<OnCommunitySubscriptionArgs> OnCommunitySubscription;
+        /// <summary>
+        /// Occurs when [on gifted subscription usernotice received].
+        /// </summary>
+        event EventHandler<OnAnonGiftedSubscriptionArgs> OnAnonGiftedSubscription;
+        /// <summary>
+        /// Occurs when [on message deleted].
+        /// </summary>
+        event EventHandler<OnMessageClearedArgs> OnMessageCleared;
+
+        /// <summary>
+        /// Occurs when [on ritual for new chatter received].
+        /// </summary>
+        event EventHandler<OnRitualNewChatterArgs> OnRitualNewChatter;
 
         /// <summary>
         /// Initializes the specified credentials.

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -379,6 +379,11 @@ namespace TwitchLib.Client
         public event EventHandler<OnReconnectedEventArgs> OnReconnected;
 
         /// <summary>
+        /// Fires when a ritual for a new chatter is received.
+        /// </summary>
+        public event EventHandler<OnRitualNewChatterArgs> OnRitualNewChatter;
+
+        /// <summary>
         /// Fires when TwitchClient attempts to host a channel it is in.
         /// </summary>
         public EventHandler OnSelfRaidError;
@@ -392,11 +397,6 @@ namespace TwitchLib.Client
         /// Fires when newly raided channel is mature audience only.
         /// </summary>
         public EventHandler OnRaidedChannelIsMatureAudience;
-
-        /// <summary>
-        /// Fires when a ritual for a new chatter is received.
-        /// </summary>
-        public EventHandler<OnRitualNewChatterArgs> OnRitualNewChatter;
 
         /// <summary>
         /// Fires when the client was unable to join a channel.


### PR DESCRIPTION
Updated the Events in the Interface to match the ones in the TwitchClient Class.
OnRitualNewChatter was getting triggered and was not set as an event and made public through the interface.
All Events that were added to the interface are actually triggered somewhere in the class and are used.
I tried to respect the way the comments for the interface were made.