### PR TITLE
Fixed misspelled RaidNotification argument of OnRaidNotificationArgs

### DIFF
--- a/TwitchLib.Client.Enums/TwitchLib.Client.Enums.csproj
+++ b/TwitchLib.Client.Enums/TwitchLib.Client.Enums.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>TwitchLib.Client.Enums</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Description>Project containing all of the enums used in TwitchLib.Client.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>swiftyspiffy, Prom3theu5, Syzuna, LuckyNoS7evin</Authors>
@@ -12,12 +12,12 @@
     <PackageProjectUrl>https://github.com/TwitchLib/TwitchLib.Client</PackageProjectUrl>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
     <Copyright>Copyright 2018</Copyright>
-    <PackageReleaseNotes>Initial release of TwitchLib.Client.Enums.</PackageReleaseNotes>
+    <PackageReleaseNotes>Slight modifications.</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/TwitchLib/TwitchLib.Client</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>twitch library irc chat c# csharp api events pubsub net standard 2.0</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
   </PropertyGroup>
 </Project>

--- a/TwitchLib.Client.Models/TwitchLib.Client.Models.csproj
+++ b/TwitchLib.Client.Models/TwitchLib.Client.Models.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>TwitchLib.Client.Models</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Description>Project contains all of the models used in TwitchLib.Client.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>swiftyspiffy, Prom3theu5, Syzuna, LuckyNoS7evin</Authors>
@@ -12,13 +12,13 @@
     <PackageProjectUrl>https://github.com/TwitchLib/TwitchLib.Client</PackageProjectUrl>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
     <Copyright>Copyright 2018</Copyright>
-    <PackageReleaseNotes>Initial release of TwitchLib.Client.</PackageReleaseNotes>
+    <PackageReleaseNotes>Enhanced parsing support and some minor changes.</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/TwitchLib/TwitchLib.Client</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>twitch library irc chat c# csharp api events pubsub net standard 2.0</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>2.1.3.0</FileVersion>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\TwitchLib.Client.Enums\TwitchLib.Client.Enums.csproj" />

--- a/TwitchLib.Client.Test/MockIClient.cs
+++ b/TwitchLib.Client.Test/MockIClient.cs
@@ -14,6 +14,8 @@ namespace TwitchLib.Client.Test
 
         public int WhisperQueueLength => throw new NotImplementedException();
 
+        public IClientOptions Options => throw new NotImplementedException();
+
         public event EventHandler<OnConnectedEventArgs> OnConnected;
         public event EventHandler<OnDataEventArgs> OnData;
         public event EventHandler<OnDisconnectedEventArgs> OnDisconnected;
@@ -62,6 +64,26 @@ namespace TwitchLib.Client.Test
         }
 
         public bool SendWhisper(string data)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void MessageThrottled(OnMessageThrottledEventArgs eventArgs)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SendFailed(OnSendFailedEventArgs eventArgs)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Error(OnErrorEventArgs eventArgs)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WhisperThrottled(OnWhisperThrottledEventArgs eventArgs)
         {
             throw new NotImplementedException();
         }

--- a/TwitchLib.Client/Events/OnRaidNotificationArgs.cs
+++ b/TwitchLib.Client/Events/OnRaidNotificationArgs.cs
@@ -5,7 +5,7 @@ namespace TwitchLib.Client.Events
 {
     public class OnRaidNotificationArgs : EventArgs
     {
-        public RaidNotification RaidNotificaiton;
+        public RaidNotification RaidNotification;
         public string Channel;
     }
 }

--- a/TwitchLib.Client/Extensions/EventInvocationExt.cs
+++ b/TwitchLib.Client/Extensions/EventInvocationExt.cs
@@ -268,7 +268,7 @@ namespace TwitchLib.Client.Extensions
             var model = new OnRaidNotificationArgs()
             {
                 Channel = channel,
-                RaidNotificaiton = new RaidNotification(badges, color, displayName, emotes, id, login, moderator, msgId, msgParamDisplayName, msgParamLogin, msgParamViewerCount,
+                RaidNotification = new RaidNotification(badges, color, displayName, emotes, id, login, moderator, msgId, msgParamDisplayName, msgParamLogin, msgParamViewerCount,
                 roomId, subscriber, systemMsg, systemMsgParsed, tmiSentTs, turbo, userType)
             };
             client.RaiseEvent("OnRaidNotification", model);

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -17,6 +17,7 @@ using TwitchLib.Communication;
 using TwitchLib.Communication.Events;
 using TwitchLib.Client.Enums;
 using TwitchLib.Communication.Interfaces;
+using TwitchLib.Communication.Clients;
 
 namespace TwitchLib.Client
 {

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -1095,7 +1095,7 @@ namespace TwitchLib.Client
             {
                 case MsgIds.Raid:
                     var raidNotification = new RaidNotification(ircMessage);
-                    OnRaidNotification?.Invoke(this, new OnRaidNotificationArgs { Channel = ircMessage.Channel, RaidNotificaiton = raidNotification });
+                    OnRaidNotification?.Invoke(this, new OnRaidNotificationArgs { Channel = ircMessage.Channel, RaidNotification = raidNotification });
                     break;
                 case MsgIds.ReSubscription:
                     var resubscriber = new ReSubscriber(ircMessage);

--- a/TwitchLib.Client/TwitchLib.Client.csproj
+++ b/TwitchLib.Client/TwitchLib.Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>TwitchLib.Client</PackageId>
-    <Version>3.0.3</Version>
+    <Version>3.0.4</Version>
     <Description>Client component of TwitchLib. This component allows you to access Twitch chat and whispers, as well as the events that are sent over this connection.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>swiftyspiffy, Prom3theu5, Syzuna, LuckyNoS7evin</Authors>
@@ -12,13 +12,13 @@
     <PackageProjectUrl>https://github.com/TwitchLib/TwitchLib.Client</PackageProjectUrl>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
     <Copyright>Copyright 2018</Copyright>
-    <PackageReleaseNotes>Replace websocket4net with TwitchLib.Communication, support for creating marker via extension command, use internal reconnection method for each client, support for community subscriptions, BitsInDollars self assignment fixed.</PackageReleaseNotes>
+    <PackageReleaseNotes>UserId added to community sub and gifted sub. RoomState bug fixed preventing join confirmation for some rooms. Anonymous gift support. OnModeratorsReceived bug preventing firing when list empty. Support for adding, removing and fetching VIPs, support for detecting removed messages.</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/TwitchLib/TwitchLib.Client</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>twitch library irc chat c# csharp api events pubsub net standard 2.0</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <AssemblyVersion>3.0.3.0</AssemblyVersion>
-    <FileVersion>3.0.3.0</FileVersion>
+    <AssemblyVersion>3.0.4.0</AssemblyVersion>
+    <FileVersion>3.0.4.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TwitchLib.Client/TwitchLib.Client.csproj
+++ b/TwitchLib.Client/TwitchLib.Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>TwitchLib.Client</PackageId>
-    <Version>3.0.0</Version>
+    <Version>3.0.3</Version>
     <Description>Client component of TwitchLib. This component allows you to access Twitch chat and whispers, as well as the events that are sent over this connection.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>swiftyspiffy, Prom3theu5, Syzuna, LuckyNoS7evin</Authors>
@@ -17,8 +17,8 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>twitch library irc chat c# csharp api events pubsub net standard 2.0</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion>3.0.0.0</FileVersion>
+    <AssemblyVersion>3.0.3.0</AssemblyVersion>
+    <FileVersion>3.0.3.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Not much to detail as far as changes.

The `OnRaidNotificationArgs` class had a property named `RaidNotificaiton`.  Corrected that spelling to `RaidNotification`.  All builds succeed and tests pass.