### PR TITLE
Fixed misspelled RaidNotification argument of OnRaidNotificationArgs

### DIFF
--- a/TwitchLib.Client/Events/OnRaidNotificationArgs.cs
+++ b/TwitchLib.Client/Events/OnRaidNotificationArgs.cs
@@ -11,9 +11,9 @@ namespace TwitchLib.Client.Events
     public class OnRaidNotificationArgs : EventArgs
     {
         /// <summary>
-        /// The raid notificaiton
+        /// The raid notification
         /// </summary>
-        public RaidNotification RaidNotificaiton;
+        public RaidNotification RaidNotification;
         /// <summary>
         /// The channel
         /// </summary>

--- a/TwitchLib.Client/Extensions/EventInvocationExt.cs
+++ b/TwitchLib.Client/Extensions/EventInvocationExt.cs
@@ -561,7 +561,7 @@ namespace TwitchLib.Client.Extensions
             OnRaidNotificationArgs model = new OnRaidNotificationArgs()
             {
                 Channel = channel,
-                RaidNotificaiton = new RaidNotification(badges, badgeInfo, color, displayName, emotes, id, login, moderator, msgId, msgParamDisplayName, msgParamLogin, msgParamViewerCount,
+                RaidNotification = new RaidNotification(badges, badgeInfo, color, displayName, emotes, id, login, moderator, msgId, msgParamDisplayName, msgParamLogin, msgParamViewerCount,
                 roomId, subscriber, systemMsg, systemMsgParsed, tmiSentTs, turbo, userType)
             };
             client.RaiseEvent("OnRaidNotification", model);

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -1325,7 +1325,7 @@ namespace TwitchLib.Client
             {
                 case MsgIds.Raid:
                     RaidNotification raidNotification = new RaidNotification(ircMessage);
-                    OnRaidNotification?.Invoke(this, new OnRaidNotificationArgs { Channel = ircMessage.Channel, RaidNotificaiton = raidNotification });
+                    OnRaidNotification?.Invoke(this, new OnRaidNotificationArgs { Channel = ircMessage.Channel, RaidNotification = raidNotification });
                     break;
                 case MsgIds.ReSubscription:
                     ReSubscriber resubscriber = new ReSubscriber(ircMessage);


### PR DESCRIPTION
Not much to detail as far as changes.

The `OnRaidNotificationArgs` class had a property named `RaidNotificaiton`.  Corrected that spelling to `RaidNotification`.  All builds succeed and tests pass.