### PR TITLE
Clear joined channels on connect

### DIFF
--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -588,6 +588,8 @@ namespace TwitchLib.Client
             if (!IsInitialized) HandleNotInitialized();
             Log($"Connecting to: {ConnectionCredentials.TwitchWebsocketURI}");
 
+			// Clear instance data
+            _joinedChannelManager.Clear();
             _client.Open();
 
             Log("Should be connected!");


### PR DESCRIPTION
Clears joined channels when calling Connect()
Issue occurs when the library gets disconnected from a network issue and a new connection is established. Because the library didn't know it was disconnected it still thinks it's joined to the channels it was previously in. Unless you use the force join flag when calling the join channel function all calls to join channels you were previously in will be ignored because it thinks you're still in them.