### PR TITLE
Fixes a typo (conneciton -> connection)

### DIFF
--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -289,7 +289,7 @@ namespace TwitchLib.Client
         public event EventHandler<OnDisconnectedEventArgs> OnDisconnected;
 
         /// <summary>
-        /// Forces when bot suffers conneciton error.
+        /// Forces when bot suffers connection error.
         /// </summary>
         public event EventHandler<OnConnectionErrorArgs> OnConnectionError;
 


### PR DESCRIPTION
This typo propagates [to the docs](https://swiftyspiffy.com/TwitchLib/Client/class_twitch_lib_1_1_client_1_1_twitch_client.html).