### PR TITLE
Don't expose IClient through events

### DIFF
--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -791,7 +791,7 @@ namespace TwitchLib.Client
         /// <param name="e">The <see cref="OnWhisperThrottledEventArgs" /> instance containing the event data.</param>
         private void _client_OnWhisperThrottled(object sender, OnWhisperThrottledEventArgs e)
         {
-            OnWhisperThrottled?.Invoke(sender, e);
+            OnWhisperThrottled?.Invoke(this, e);
         }
 
         /// <summary>
@@ -801,7 +801,7 @@ namespace TwitchLib.Client
         /// <param name="e">The <see cref="OnMessageThrottledEventArgs" /> instance containing the event data.</param>
         private void _client_OnMessageThrottled(object sender, OnMessageThrottledEventArgs e)
         {
-            OnMessageThrottled?.Invoke(sender, e);
+            OnMessageThrottled?.Invoke(this, e);
         }
 
         /// <summary>
@@ -821,7 +821,7 @@ namespace TwitchLib.Client
         /// <param name="e">The <see cref="OnDisconnectedEventArgs" /> instance containing the event data.</param>
         private void _client_OnDisconnected(object sender, OnDisconnectedEventArgs e)
         {
-            OnDisconnected?.Invoke(sender, e);
+            OnDisconnected?.Invoke(this, e);
             _joinedChannelManager.Clear();
         }
 
@@ -832,7 +832,7 @@ namespace TwitchLib.Client
         /// <param name="e">The <see cref="OnReconnectedEventArgs" /> instance containing the event data.</param>
         private void _client_OnReconnected(object sender, OnReconnectedEventArgs e)
         {
-            OnReconnected?.Invoke(sender, e);
+            OnReconnected?.Invoke(this, e);
         }
 
         /// <summary>


### PR DESCRIPTION
A couple of TwitchClient events currently use the IClient instance as sender object.
This is at the very least confusing since the majority use the object instance (this) which is the main user facing component.

My primary motivation was the fact that I have multiple TwitchClient instances active at the same time and I am unable to properly identify them in those events without accessing their private _client member variable which should not be the way to go.
This will allow me and other users to (safely) cast the sender object to work with the TwitchClient instance.

I have no idea how widely those those events (or more importantly the sender parameter) are used, but this change is still worth considering given it unifies the event parameters and simplifies using multiple instances concurrently.