### PR TITLE
move RawIrcMessage from ChatMessage to TwitchLibMessage

### DIFF
--- a/TwitchLib.Client.Models/ChatMessage.cs
+++ b/TwitchLib.Client.Models/ChatMessage.cs
@@ -70,9 +70,6 @@ namespace TwitchLib.Client.Models
         /// <summary>Experimental property noisy determination by Twitch.</summary>
         public Noisy Noisy { get; }
 
-        /// <summary>Raw IRC-style text received from Twitch.</summary>
-        public string RawIrcMessage { get; }
-
         /// <summary>Unique identifier of chat room.</summary>
         public string RoomId { get; }
 

--- a/TwitchLib.Client.Models/TwitchLibMessage.cs
+++ b/TwitchLib.Client.Models/TwitchLibMessage.cs
@@ -37,5 +37,8 @@ namespace TwitchLib.Client.Models
 
         /// <summary>User type can be viewer, moderator, global mod, admin, or staff</summary>
         public UserType UserType { get; protected set; }
+        
+        /// <summary>Raw IRC-style text received from Twitch.</summary>
+        public string RawIrcMessage { get; protected set; }
     }
 }

--- a/TwitchLib.Client.Models/WhisperMessage.cs
+++ b/TwitchLib.Client.Models/WhisperMessage.cs
@@ -59,6 +59,7 @@ namespace TwitchLib.Client.Models
         {
             Username = ircMessage.User;
             BotUsername = botUsername;
+            RawIrcMessage = ircMessage.ToString();
 
             Message = ircMessage.Message;
             foreach (var tag in ircMessage.Tags.Keys)


### PR DESCRIPTION
I've noticed that `WhisperMessage` does not have the `RawIrcMessage` field like `ChatMessage` does, and had a quick check in the code why that might be. Trying it out real quick showed that there doesn't seem to be anything fundamentally different between chat messages and whisper messages.
This pull request attempts to eliminate that discrepancy by moving the `RawIrcMessage` property to `TwitchLibMessage`, which is the base class for both `ChatMessage` and `WhisperMessage`