### PR TITLE
ability to disable individual capability requests

### DIFF
--- a/TwitchLib.Client.Models/ConnectionCredentials.cs
+++ b/TwitchLib.Client.Models/ConnectionCredentials.cs
@@ -17,12 +17,16 @@ namespace TwitchLib.Client.Models
         /// <summary>Property representing bot's username.</summary>
         public string TwitchUsername { get; }
 
+        /// <summary>Property representing capability requests sent to twitch.</summary>
+        public Capabilities Capabilities { get; }
+
         /// <summary>Constructor for ConnectionCredentials object.</summary>
         public ConnectionCredentials(
             string twitchUsername,
             string twitchOAuth,
             string twitchWebsocketURI = DefaultWebSocketUri,
-            bool disableUsernameCheck = false)
+            bool disableUsernameCheck = false,
+            Capabilities capabilities = null)
         {
             if (!disableUsernameCheck && !new Regex("^([a-zA-Z0-9][a-zA-Z0-9_]{3,25})$").Match(twitchUsername).Success)
                 throw new Exception($"Twitch username does not appear to be valid. {twitchUsername}");
@@ -37,6 +41,30 @@ namespace TwitchLib.Client.Models
             }
 
             TwitchWebsocketURI = twitchWebsocketURI;
+
+            if (capabilities == null)
+                capabilities = new Capabilities();
+            Capabilities = capabilities;
+        }
+    }
+
+    /// <summary>Class used to store capacity request settings used when connecting to Twitch</summary>
+    public class Capabilities
+    {
+        /// <summary>Adds membership state event data. By default, we do not send this data to clients without this capability.</summary>
+        public bool Membership { get; }
+
+        /// <summary>Adds IRC V3 message tags to several commands, if enabled with the commands capability.</summary>
+        public bool Tags { get; }
+
+        /// <summary>Enables several Twitch-specific commands.</summary>
+        public bool Commands { get; }
+
+        public Capabilities(bool membership = true, bool tags = true, bool commands = true)
+        {
+            Membership = membership;
+            Tags = tags;
+            Commands = commands;
         }
     }
 }

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -905,9 +905,12 @@ namespace TwitchLib.Client
             _client.Send(Rfc2812.Nick(ConnectionCredentials.TwitchUsername));
             _client.Send(Rfc2812.User(ConnectionCredentials.TwitchUsername, 0, ConnectionCredentials.TwitchUsername));
 
-            _client.Send("CAP REQ twitch.tv/membership");
-            _client.Send("CAP REQ twitch.tv/commands");
-            _client.Send("CAP REQ twitch.tv/tags");
+            if (ConnectionCredentials.Capabilities.Membership)
+                _client.Send("CAP REQ twitch.tv/membership");
+            if (ConnectionCredentials.Capabilities.Commands)
+                _client.Send("CAP REQ twitch.tv/commands");
+            if (ConnectionCredentials.Capabilities.Tags)
+                _client.Send("CAP REQ twitch.tv/tags");
 
             if (_autoJoinChannel != null)
             {


### PR DESCRIPTION
New model in ConnectionCredentials containing booleans for each of the supported capabilities.

Tested to ensure the default behavior is all three enabled, and also tested disabling each individual one, as well as all of them.