### PR TITLE
Support for gifted subscriptions that get continued by the recipient

### DIFF
--- a/TwitchLib.Client.Models/ContinuedGiftedSubscription.cs
+++ b/TwitchLib.Client.Models/ContinuedGiftedSubscription.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+
+using TwitchLib.Client.Enums;
+using TwitchLib.Client.Models.Internal;
+
+namespace TwitchLib.Client.Models
+{
+    public class ContinuedGiftedSubscription
+    {
+        //@badge-info=subscriber/11;badges=subscriber/9;color=#DAA520;display-name=Varanid;emotes=;flags=;id=a2d384c1-c30a-409e-8001-9e7d8f9c784d;login=varanid;mod=0;msg-id=giftpaidupgrade;msg-param-sender-login=cletusbueford;msg-param-sender-name=CletusBueford;room-id=44338537;subscriber=1;system-msg=Varanid\sis\scontinuing\sthe\sGift\sSub\sthey\sgot\sfrom\sCletusBueford!;tmi-sent-ts=1612497386372;user-id=67505836;user-type= :tmi.twitch.tv USERNOTICE #burkeblack 
+
+        public List<KeyValuePair<string, string>> Badges { get; }
+
+        public List<KeyValuePair<string, string>> BadgeInfo { get; }
+
+        public string Color { get; }
+
+        public string DisplayName { get; }
+
+        public string Emotes { get; }
+
+        public string Flags { get; }
+
+        public string Id { get; }
+
+        public string Login { get; }
+
+        public bool IsModerator { get; }
+
+        public string MsgId { get; }
+
+        public string MsgParamSenderLogin { get; }
+
+        public string MsgParamSenderName { get; }
+
+        public string RoomId { get; }
+
+        public bool IsSubscriber { get; }
+
+        public string SystemMsg { get; }
+
+        public string TmiSentTs { get; }
+
+        public string UserId { get; }
+
+        public UserType UserType { get; }
+
+        public ContinuedGiftedSubscription(IrcMessage ircMessage)
+        {
+            foreach (var tag in ircMessage.Tags.Keys)
+            {
+                var tagValue = ircMessage.Tags[tag];
+
+                switch (tag)
+                {
+                    case Tags.SystemMsg:
+                        SystemMsg = tagValue;
+                        break;
+                    case Tags.Flags:
+                        Flags = tagValue;
+                        break;
+                    case Tags.MsgParamSenderLogin:
+                        MsgParamSenderLogin = tagValue;
+                        break;
+                    case Tags.MsgParamSenderName:
+                        MsgParamSenderName = tagValue;
+                        break;
+                    case Tags.Badges:
+                        Badges = Common.Helpers.ParseBadges(tagValue);
+                        break;
+                    case Tags.BadgeInfo:
+                        BadgeInfo = Common.Helpers.ParseBadges(tagValue);
+                        break;
+                    case Tags.Color:
+                        Color = tagValue;
+                        break;
+                    case Tags.DisplayName:
+                        DisplayName = tagValue;
+                        break;
+                    case Tags.Emotes:
+                        Emotes = tagValue;
+                        break;
+                    case Tags.Id:
+                        Id = tagValue;
+                        break;
+                    case Tags.Login:
+                        Login = tagValue;
+                        break;
+                    case Tags.Mod:
+                        IsModerator = Common.Helpers.ConvertToBool(tagValue);
+                        break;
+                    case Tags.MsgId:
+                        MsgId = tagValue;
+                        break;
+                    case Tags.RoomId:
+                        RoomId = tagValue;
+                        break;
+                    case Tags.Subscriber:
+                        IsSubscriber = Common.Helpers.ConvertToBool(tagValue);
+                        break;
+                    case Tags.TmiSentTs:
+                        TmiSentTs = tagValue;
+                        break;
+                    case Tags.UserId:
+                        UserId = tagValue;
+                        break;
+                    case Tags.UserType:
+                        switch (tagValue)
+                        {
+                            case "mod":
+                                UserType = UserType.Moderator;
+                                break;
+                            case "global_mod":
+                                UserType = UserType.GlobalModerator;
+                                break;
+                            case "admin":
+                                UserType = UserType.Admin;
+                                break;
+                            case "staff":
+                                UserType = UserType.Staff;
+                                break;
+                            default:
+                                UserType = UserType.Viewer;
+                                break;
+                        }
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/TwitchLib.Client.Models/Internal/MsgIds.cs
+++ b/TwitchLib.Client.Models/Internal/MsgIds.cs
@@ -33,6 +33,7 @@
         public const string R9KOn = "r9k_on";
         public const string SubGift = "subgift";
         public const string CommunitySubscription = "submysterygift";
+        public const string ContinuedGiftedSubscription = "giftpaidupgrade";
         public const string Subscription = "sub";
         public const string SubsOff = "subs_off";
         public const string SubsOn = "subs_on";

--- a/TwitchLib.Client.Models/Internal/Tags.cs
+++ b/TwitchLib.Client.Models/Internal/Tags.cs
@@ -14,6 +14,7 @@
         public const string Emotes = "emotes";
         public const string EmoteOnly = "emote-only";
         public const string EmotesSets = "emote-sets";
+        public const string Flags = "flags";
         public const string FollowersOnly = "followers-only";
         public const string Id = "id";
         public const string Login = "login";

--- a/TwitchLib.Client/Events/OnContinuedGiftedSubscriptionArgs.cs
+++ b/TwitchLib.Client/Events/OnContinuedGiftedSubscriptionArgs.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using TwitchLib.Client.Models;
+
+namespace TwitchLib.Client.Events
+{
+    /// <summary>
+    /// Class OnContinuedGiftedSubscriptionArgs.
+    /// Implements the <see cref="System.EventArgs" />
+    /// </summary>
+    /// <seealso cref="System.EventArgs" />
+    public class OnContinuedGiftedSubscriptionArgs : EventArgs
+    {
+        /// <summary>
+        /// Property representing the information of the subscription that was originally gifted, and is now continued by the user.
+        /// </summary>
+        public ContinuedGiftedSubscription ContinuedGiftedSubscription;
+        /// <summary>
+        /// Property representing the Twitch channel this event fired from.
+        /// </summary>
+        public string Channel;
+    }
+}

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -354,6 +354,11 @@ namespace TwitchLib.Client
         public event EventHandler<OnCommunitySubscriptionArgs> OnCommunitySubscription;
 
         /// <summary>
+        /// 
+        /// </summary>
+        public event EventHandler<OnContinuedGiftedSubscriptionArgs> OnContinuedGiftedSubscription;
+
+        /// <summary>
         /// Fires when a Message has been throttled.
         /// </summary>
         public event EventHandler<OnMessageThrottledEventArgs> OnMessageThrottled;
@@ -1404,6 +1409,10 @@ namespace TwitchLib.Client
                 case MsgIds.CommunitySubscription:
                     CommunitySubscription communitySubscription = new CommunitySubscription(ircMessage);
                     OnCommunitySubscription?.Invoke(this, new OnCommunitySubscriptionArgs { GiftedSubscription = communitySubscription, Channel = ircMessage.Channel });
+                    break;
+                case MsgIds.ContinuedGiftedSubscription:
+                    ContinuedGiftedSubscription continuedGiftedSubscription = new ContinuedGiftedSubscription(ircMessage);
+                    OnContinuedGiftedSubscription?.Invoke(this, new OnContinuedGiftedSubscriptionArgs { ContinuedGiftedSubscription = continuedGiftedSubscription, Channel = ircMessage.Channel });
                     break;
                 case MsgIds.Subscription:
                     Subscriber subscriber = new Subscriber(ircMessage);


### PR DESCRIPTION
Twitch has an event where a user whos subscription was gifted to them chooses to continue the subscription by paying for it themselves. This is a "giftpaidupgrade" event type, but I named it "ContinuedGiftedSubscription" based on the message that shows up in chat.

TwitchLib message currently:
```
Unaccounted for: @badge-info=subscriber/11;badges=subscriber/9;color=#DAA520;display-name=Varanid;emotes=;flags=;id=a2d384c1-c30a-409e-8001-9e7d8f9c784d;login=varanid;mod=0;msg-id=giftpaidupgrade;msg-param-sender-login=cletusbueford;msg-param-sender-name=CletusBueford;room-id=44338537;subscriber=1;system-msg=Varanid\sis\scontinuing\sthe\sGift\sSub\sthey\sgot\sfrom\sCletusBueford!;tmi-sent-ts=1612497386372;user-id=67505836;user-type= :tmi.twitch.tv USERNOTICE #burkeblack (please create a TwitchLib GitHub issue :P)
```

Tested with the following code:
```
namespace TwitchLibClientTester
{
    class Program
    {

        private static TwitchLib.Client.TwitchClient client;
        static void Main(string[] args)
        {
            client = new TwitchLib.Client.TwitchClient();
            client.Initialize(new TwitchLib.Client.Models.ConnectionCredentials("swiftyspiffy", "<token>"), "burkeblack");
            client.OnConnected += Client_OnConnected;
            client.OnJoinedChannel += Client_OnJoinedChannel;
            client.OnContinuedGiftedSubscription += Client_OnContinuedGiftedSubscription;
            client.Connect();
            Console.ReadLine();
            client.OnReadLineTest("@badge-info=subscriber/11;badges=subscriber/9;color=#DAA520;display-name=Varanid;emotes=;flags=;id=a2d384c1-c30a-409e-8001-9e7d8f9c784d;login=varanid;mod=0;msg-id=giftpaidupgrade;msg-param-sender-login=cletusbueford;msg-param-sender-name=CletusBueford;room-id=44338537;subscriber=1;system-msg=Varanid\\sis\\scontinuing\\sthe\\sGift\\sSub\\sthey\\sgot\\sfrom\\sCletusBueford!;tmi-sent-ts=1612497386372;user-id=67505836;user-type= :tmi.twitch.tv USERNOTICE #burkeblack");
            Console.ReadLine();
        }

        private static void Client_OnContinuedGiftedSubscription(object sender, TwitchLib.Client.Events.OnContinuedGiftedSubscriptionArgs e)
        {
            Console.WriteLine("Received event!");
        }

        private static void Client_OnJoinedChannel(object sender, TwitchLib.Client.Events.OnJoinedChannelArgs e)
        {
            Console.WriteLine($"Joined channel!");
        }

        private static void Client_OnConnected(object sender, TwitchLib.Client.Events.OnConnectedArgs e)
        {
            Console.WriteLine($"Connected!");
        }
    }
}
```

Breakpoint on "Received event" confirms populated event args.