### PR TITLE
Repopulate the auto channel join queue on reconnects

### DIFF
--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -57,10 +57,6 @@ namespace TwitchLib.Client
         /// </summary>
         private readonly ClientProtocol _protocol;
         /// <summary>
-        /// The automatic join channel
-        /// </summary>
-        private string _autoJoinChannel;
-        /// <summary>
         /// The currently joining channels
         /// </summary>
         private bool _currentlyJoiningChannels;
@@ -919,10 +915,7 @@ namespace TwitchLib.Client
             if (ConnectionCredentials.Capabilities.Tags)
                 _client.Send("CAP REQ twitch.tv/tags");
 
-            if (_autoJoinChannel != null)
-            {
-                JoinChannel(_autoJoinChannel);
-            } else if(_joinChannelQueue != null && _joinChannelQueue.Count > 0)
+            if(_joinChannelQueue != null && _joinChannelQueue.Count > 0)
             {
                 QueueingJoinCheck();
             }
@@ -1295,7 +1288,7 @@ namespace TwitchLib.Client
         /// </summary>
         private void Handle004()
         {
-            OnConnected?.Invoke(this, new OnConnectedArgs { AutoJoinChannel = _autoJoinChannel, BotUsername = TwitchUsername });
+            OnConnected?.Invoke(this, new OnConnectedArgs { BotUsername = TwitchUsername });
         }
 
         /// <summary>

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -689,6 +689,8 @@ namespace TwitchLib.Client
         {
             if (!IsInitialized) HandleNotInitialized();
             Log($"Reconnecting to Twitch");
+            foreach (var channel in _joinedChannelManager.GetJoinedChannels())
+                _joinChannelQueue.Enqueue(channel);
             _joinedChannelManager.Clear();
             _client.Reconnect();
         }


### PR DESCRIPTION
This issue was initially brought forward in #140  and then again in  #163 . Thanks @Felk for bringing attention to this.

The auto channel join queue was previously not populated with the currently joined channels when a reconnect occurs, meaning when the client reconnects to Twitch, it has no channels to automatically join, and the programmer has to write logic in `OnConnected` to rejoin them.

This should fix that problem.

Currently:
```
. . .
Finished channel joining queue.
Received: @badge-info=founder/80;badges=moderator/1,founder/0,bits/25000;client-nonce=15be6227cbda00046a1f955522bfa75c;color=#CC00C5;display-name=swiftyspiffy;emotes=;flags=;id=783279b9-952d-4fda-ac61-b92143c3c885;mod=1;room-id=44338537;subscriber=0;tmi-sent-ts=1613261977689;turbo=0;user-id=40876073;user-type=mod :swiftyspiffy!swiftyspiffy@swiftyspiffy.tmi.twitch.tv PRIVMSG #burkeblack :asd
Received: :tmi.twitch.tv RECONNECT #burkeblack
Reconnecting to Twitch
Connected!
Received: :tmi.twitch.tv 001 swiftyspiffy :Welcome, GLHF!
Received: :tmi.twitch.tv 002 swiftyspiffy :Your host is tmi.twitch.tv
Received: :tmi.twitch.tv 003 swiftyspiffy :This server is rather new
Received: :tmi.twitch.tv 004 swiftyspiffy :-
Connected!
Received: :tmi.twitch.tv 372 swiftyspiffy :You are in a maze of twisty passages, all alike.
Received: :tmi.twitch.tv 375 swiftyspiffy :-
Received: :tmi.twitch.tv 376 swiftyspiffy :>
Received: :tmi.twitch.tv CAP * ACK :twitch.tv/membership
Unaccounted for: :tmi.twitch.tv CAP * ACK :twitch.tv/membership (please create a TwitchLib GitHub issue :P)
Received: :tmi.twitch.tv CAP * ACK :twitch.tv/commands
Unaccounted for: :tmi.twitch.tv CAP * ACK :twitch.tv/commands (please create a TwitchLib GitHub issue :P)
Received: :tmi.twitch.tv CAP * ACK :twitch.tv/tags
Unaccounted for: :tmi.twitch.tv CAP * ACK :twitch.tv/tags (please create a TwitchLib GitHub issue :P)
```

With new code:
```
. . .
Finished channel joining queue.
Received: :onlygumbo!onlygumbo@onlygumbo.tmi.twitch.tv PART #burkeblack
Received: @badge-info=subscriber/78;badges=moderator/1,subscriber/78;color=#8A2BE2;display-name=The_Kraken_Bot;emotes=305196051:180-188;flags=151-178:;id=5b5c42a0-f3be-47a9-939b-4dd7ba30898e;mod=1;room-id=44338537;subscriber=1;tmi-sent-ts=1613262173450;turbo=0;user-id=66137196;user-type=mod :the_kraken_bot!the_kraken_bot@the_kraken_bot.tmi.twitch.tv PRIVMSG #burkeblack :☺ACTION Unlimited downloads of stock videos, royalty-free music, photos, graphics & more. ENVATO ELEMENTS; the only creative subscription you need. More info: https://elements.envato.com/ burkeHype☺
Received: @badge-info=founder/80;badges=moderator/1,founder/0,bits/25000;client-nonce=1314b4c6db2b6a93f34b32bd11168068;color=#CC00C5;display-name=swiftyspiffy;emotes=;flags=;id=865449ee-c42d-4a51-b645-cb0482d1d978;mod=1;room-id=44338537;subscriber=0;tmi-sent-ts=1613262220139;turbo=0;user-id=40876073;user-type=mod :swiftyspiffy!swiftyspiffy@swiftyspiffy.tmi.twitch.tv PRIVMSG #burkeblack :asd
Received: :tmi.twitch.tv RECONNECT #burkeblack
Reconnecting to Twitch
Connected!
Joining channel: burkeblack
Received: :tmi.twitch.tv 001 swiftyspiffy :Welcome, GLHF!
Received: :tmi.twitch.tv 002 swiftyspiffy :Your host is tmi.twitch.tv
Received: :tmi.twitch.tv 003 swiftyspiffy :This server is rather new
Received: :tmi.twitch.tv 004 swiftyspiffy :-
Connected!
Received: :tmi.twitch.tv 372 swiftyspiffy :You are in a maze of twisty passages, all alike.
Received: :tmi.twitch.tv 375 swiftyspiffy :-
Received: :tmi.twitch.tv 376 swiftyspiffy :>
Received: :tmi.twitch.tv CAP * ACK :twitch.tv/membership
Unaccounted for: :tmi.twitch.tv CAP * ACK :twitch.tv/membership (please create a TwitchLib GitHub issue :P)
Received: :tmi.twitch.tv CAP * ACK :twitch.tv/commands
Unaccounted for: :tmi.twitch.tv CAP * ACK :twitch.tv/commands (please create a TwitchLib GitHub issue :P)
Received: :tmi.twitch.tv CAP * ACK :twitch.tv/tags
Unaccounted for: :tmi.twitch.tv CAP * ACK :twitch.tv/tags (please create a TwitchLib GitHub issue :P)
Received: :swiftyspiffy!swiftyspiffy@swiftyspiffy.tmi.twitch.tv JOIN #burkeblack
Received: @badge-info=;badges=moderator/1,bits/25000;color=#CC00C5;display-name=swiftyspiffy;emote-sets=0,75,5534,5628,19194,27162,27163,33563,175403,484578,571946,758802,865926,1654802,300206295,300374282,300548756,472873131,477339272,488737509,537206155,564265402,592920959,610186276,827105474,841286678,1248070715,1323553252,1549759808;mod=1;subscriber=1;user-type=mod :tmi.twitch.tv USERSTATE #burkeblack
Received: :swiftyspiffy.tmi.twitch.tv 366 swiftyspiffy #burkeblack :End of /NAMES list
Finished channel joining queue.
```