### PR TITLE
Support primepaidupgrade event

### DIFF
--- a/TwitchLib.Client.Models/Internal/MsgIds.cs
+++ b/TwitchLib.Client.Models/Internal/MsgIds.cs
@@ -24,6 +24,7 @@
         public const string NoVIPs = "no_vips";
         public const string MsgChannelSuspended = "msg_channel_suspended";
         public const string NoPermission = "no_permission";
+        public const string PrimePaidUprade = "primepaidupgrade";
         public const string Raid = "raid";
         public const string RaidErrorSelf = "raid_error_self";
         public const string RaidNoticeMature = "raid_notice_mature";

--- a/TwitchLib.Client.Models/PrimePaidSubscriber.cs
+++ b/TwitchLib.Client.Models/PrimePaidSubscriber.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Text;
+using TwitchLib.Client.Enums;
+using TwitchLib.Client.Models.Internal;
+
+namespace TwitchLib.Client.Models
+{
+    public class PrimePaidSubscriber : SubscriberBase
+    {
+        public PrimePaidSubscriber(IrcMessage ircMessage) : base(ircMessage)
+        {
+        }
+
+        public PrimePaidSubscriber(
+            List<KeyValuePair<string, string>> badges,
+            List<KeyValuePair<string, string>> badgeInfo,
+            string colorHex,
+            Color color,
+            string displayName,
+            string emoteSet,
+            string id,
+            string login,
+            string systemMessage,
+            string msgId,
+            string msgParamCumulativeMonths,
+            string msgParamStreakMonths,
+            bool msgParamShouldShareStreak,
+            string systemMessageParsed,
+            string resubMessage,
+            SubscriptionPlan subscriptionPlan,
+            string subscriptionPlanName,
+            string roomId,
+            string userId,
+            bool isModerator,
+            bool isTurbo,
+            bool isSubscriber,
+            bool isPartner,
+            string tmiSentTs,
+            UserType userType,
+            string rawIrc,
+            string channel,
+            int months = 0)
+            : base(badges,
+                  badgeInfo,
+                  colorHex,
+                  color,
+                  displayName,
+                  emoteSet,
+                  id,
+                  login,
+                  systemMessage,
+                  msgId,
+                  msgParamCumulativeMonths,
+                  msgParamStreakMonths,
+                  msgParamShouldShareStreak,
+                  systemMessageParsed,
+                  resubMessage,
+                  subscriptionPlan,
+                  subscriptionPlanName,
+                  roomId,
+                  userId,
+                  isModerator,
+                  isTurbo,
+                  isSubscriber,
+                  isPartner,
+                  tmiSentTs,
+                  userType,
+                  rawIrc,
+                  channel,
+                  months)
+        {
+        }
+    }
+}

--- a/TwitchLib.Client/Events/OnPrimePaidSubscriberArgs.cs
+++ b/TwitchLib.Client/Events/OnPrimePaidSubscriberArgs.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using TwitchLib.Client.Models;
+
+namespace TwitchLib.Client.Events
+{
+    /// <summary>
+    /// Args representing prime gaming sub -> paid sub event.
+    /// Implements the <see cref="System.EventArgs" />
+    /// </summary>
+    /// <seealso cref="System.EventArgs" />
+    /// <inheritdoc />
+    public class OnPrimePaidSubscriberArgs : EventArgs
+    {
+        /// <summary>
+        /// Property representing prime gaming -> paid subscriber object.
+        /// </summary>
+        public PrimePaidSubscriber PrimePaidSubscriber;
+        /// <summary>
+        /// Property representing the Twitch channel this event fired from.
+        /// </summary>
+        public string Channel;
+    }
+}

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -255,6 +255,11 @@ namespace TwitchLib.Client
         public event EventHandler<OnReSubscriberArgs> OnReSubscriber;
 
         /// <summary>
+        /// Fires when a current Prime gaming subscriber converts to a paid subscription.
+        /// </summary>
+        public event EventHandler<OnPrimePaidSubscriberArgs> OnPrimePaidSubscriber;
+
+        /// <summary>
         /// Fires when a hosted streamer goes offline and hosting is killed.
         /// </summary>
         public event EventHandler OnHostLeft;
@@ -1417,6 +1422,10 @@ namespace TwitchLib.Client
                 case MsgIds.Subscription:
                     Subscriber subscriber = new Subscriber(ircMessage);
                     OnNewSubscriber?.Invoke(this, new OnNewSubscriberArgs { Subscriber = subscriber, Channel = ircMessage.Channel });
+                    break;
+                case MsgIds.PrimePaidUprade:
+                    PrimePaidSubscriber primePaidSubscriber = new PrimePaidSubscriber(ircMessage);
+                    OnPrimePaidSubscriber?.Invoke(this, new OnPrimePaidSubscriberArgs { PrimePaidSubscriber = primePaidSubscriber, Channel = ircMessage.Channel });
                     break;
                 default:
                     OnUnaccountedFor?.Invoke(this, new OnUnaccountedForArgs { BotUsername = TwitchUsername, Channel = ircMessage.Channel, Location = "UserNoticeHandling", RawIRC = ircMessage.ToString() });


### PR DESCRIPTION
This event fires when a subscriber to a channel upgrades from a Prime Gaming subscription to a paid subscription (any tier).

Tested against the following IRC string, and working:
```
@badge-info=subscriber/1;badges=subscriber/0,premium/1;color=;display-name=swiftyspiffy;emotes=;flags=;id=fd9f568c-325b-447f-aa03-e4dc08d661d5;login=swiftyspiffy;mod=1;msg-id=primepaidupgrade;msg-param-sub-plan=1000;room-id=44338537;subscriber=1;system-msg=swiftyspiffy\\sconverted\\sfrom\\sa\\sTwitch\\sPrime\\ssub\\sto\\sa\\sTier\\s1\\ssub!;tmi-sent-ts=1553627414793;user-id=40876073;user-type= :tmi.twitch.tv USERNOTICE #burkeblack
```