### PR TITLE
fix param multi month gift duration

### DIFF
--- a/TwitchLib.Client.Models/Internal/Tags.cs
+++ b/TwitchLib.Client.Models/Internal/Tags.cs
@@ -61,7 +61,7 @@
         public const string Turbo = "turbo";                // Deprecated, use badges instead
         public const string UserId = "user-id";
         public const string UserType = "user-type";         // Deprecated, use badges instead
-        public const string MsgParamMultiMonthGiftDuration = "msg-params-gift-months";            // Sent only on subgift, anonsubgift
+        public const string MsgParamMultiMonthGiftDuration = "msg-param-gift-months";             // Sent only on subgift, anonsubgift
         public const string TargetUserId = "target-user-id";
     }
 }


### PR DESCRIPTION
Twitch originally misspelled the tag in both their announcement and the documentation page,
but have fixed the mistake in the documentation by now, as can be inferred by this uservoice post:
https://twitch.uservoice.com/forums/310213-developers/suggestions/40811302-new-irc-tag-msg-params-gift-months-in-docs-is-ac