### PR TITLE
Include xml comments into nuget packages

### DIFF
--- a/TwitchLib.Client.Enums/TwitchLib.Client.Enums.csproj
+++ b/TwitchLib.Client.Enums/TwitchLib.Client.Enums.csproj
@@ -20,5 +20,6 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyVersion>3.2.3</AssemblyVersion>
     <FileVersion>3.2.3</FileVersion>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 </Project>

--- a/TwitchLib.Client.Models/TwitchLib.Client.Models.csproj
+++ b/TwitchLib.Client.Models/TwitchLib.Client.Models.csproj
@@ -20,6 +20,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyVersion>3.2.3</AssemblyVersion>
     <FileVersion>3.2.3</FileVersion>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\TwitchLib.Client.Enums\TwitchLib.Client.Enums.csproj" />

--- a/TwitchLib.Client/TwitchLib.Client.csproj
+++ b/TwitchLib.Client/TwitchLib.Client.csproj
@@ -20,6 +20,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyVersion>3.2.3</AssemblyVersion>
     <FileVersion>3.2.3</FileVersion>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Currently XML comments aren't included in the Nuget package and therefore don't show in the users intellisense.
This PR aims to include the comments to enable the users intellisense to support them with information they may need.