### PR TITLE
Handle capacity, rate limit, and duplicate events from Twitch

### DIFF
--- a/TwitchLib.Client.Models/Internal/MsgIds.cs
+++ b/TwitchLib.Client.Models/Internal/MsgIds.cs
@@ -27,6 +27,7 @@
         public const string MsgRequiresVerifiedPhoneNumber = "msg_requires_verified_phone_number";
         public const string MsgVerifiedEmail = "msg_verified_email";
         public const string MsgRateLimit = "msg_ratelimit";
+        public const string MsgDuplicate = "msg_duplicate";
         public const string NoPermission = "no_permission";
         public const string PrimePaidUprade = "primepaidupgrade";
         public const string Raid = "raid";

--- a/TwitchLib.Client.Models/Internal/MsgIds.cs
+++ b/TwitchLib.Client.Models/Internal/MsgIds.cs
@@ -26,6 +26,7 @@
         public const string MsgChannelSuspended = "msg_channel_suspended";
         public const string MsgRequiresVerifiedPhoneNumber = "msg_requires_verified_phone_number";
         public const string MsgVerifiedEmail = "msg_verified_email";
+        public const string MsgRateLimit = "msg_ratelimit";
         public const string NoPermission = "no_permission";
         public const string PrimePaidUprade = "primepaidupgrade";
         public const string Raid = "raid";

--- a/TwitchLib.Client/Events/OnDuplicateArgs.cs
+++ b/TwitchLib.Client/Events/OnDuplicateArgs.cs
@@ -3,12 +3,12 @@
 namespace TwitchLib.Client.Events
 {
     /// <summary>
-    /// Args representing a NOTICE telling the client that a rate limit has been hit.
+    /// Args representing a NOTICE telling the client that duplicate messages are not allowed.
     /// Implements the <see cref="System.EventArgs" />
     /// </summary>
     /// <seealso cref="System.EventArgs" />
     /// <inheritdoc />
-    public class OnRateLimitArgs : EventArgs
+    public class OnDuplicateArgs : EventArgs
     {
         /// <summary>
         /// Property representing message send with the NOTICE

--- a/TwitchLib.Client/Events/OnRateLimitArgs.cs
+++ b/TwitchLib.Client/Events/OnRateLimitArgs.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace TwitchLib.Client.Events
+{
+    /// <summary>
+    /// Args representing a NOTICE telling the client that a verified phone number is required to chat.
+    /// Implements the <see cref="System.EventArgs" />
+    /// </summary>
+    /// <seealso cref="System.EventArgs" />
+    /// <inheritdoc />
+    public class OnRateLimitArgs : EventArgs
+    {
+        /// <summary>
+        /// Property representing message send with the NOTICE
+        /// </summary>
+        public string Message;
+        /// <summary>
+        /// Property representing channel bot is connected to.
+        /// </summary>
+        public string Channel;
+    }
+}

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -1034,7 +1034,6 @@ namespace TwitchLib.Client
             {
                 OnIncorrectLogin?.Invoke(this, new OnIncorrectLoginArgs { Exception = new ErrorLoggingInException(ircMessage.ToString(), TwitchUsername) });
             }
-
             switch (ircMessage.Command)
             {
                 case IrcCommand.PrivMsg:
@@ -1105,10 +1104,11 @@ namespace TwitchLib.Client
                 case IrcCommand.Mode:
                     HandleMode(ircMessage);
                     break;
-                case IrcCommand.Unknown:
-                    OnUnaccountedFor?.Invoke(this, new OnUnaccountedForArgs { BotUsername = TwitchUsername, Channel = null, Location = "HandleIrcMessage", RawIRC = ircMessage.ToString() });
-                    UnaccountedFor(ircMessage.ToString());
+                case IrcCommand.Cap:
+                    HandleCap(ircMessage);
                     break;
+                case IrcCommand.Unknown:
+                    // fall through
                 default:
                     OnUnaccountedFor?.Invoke(this, new OnUnaccountedForArgs { BotUsername = TwitchUsername, Channel = null, Location = "HandleIrcMessage", RawIRC = ircMessage.ToString() });
                     UnaccountedFor(ircMessage.ToString());
@@ -1474,6 +1474,16 @@ namespace TwitchLib.Client
             {
                 OnModeratorLeft?.Invoke(this, new OnModeratorLeftArgs { Channel = ircMessage.Channel, Username = ircMessage.Message.Split(' ')[1] });
             }
+        }
+
+        /// <summary>
+        /// Handles the Cap
+        /// </summary>
+        /// <param name="ircMessage">The irc message</param>
+        private void HandleCap(IrcMessage ircMessage)
+        {
+            // do nothing
+            return;
         }
 
         #endregion

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -400,6 +400,11 @@ namespace TwitchLib.Client
         public event EventHandler<OnRateLimitArgs> OnRateLimit;
 
         /// <summary>
+        /// Occurs when sending duplicate messages and user is not permitted to do so
+        /// </summary>
+        public event EventHandler<OnDuplicateArgs> OnDuplicate;
+
+        /// <summary>
         /// Occurs when chatting in a channel that the user is banned in bcs of an already banned alias with the same Email
         /// </summary>
         public event EventHandler<OnBannedEmailAliasArgs> OnBannedEmailAlias;
@@ -1223,6 +1228,9 @@ namespace TwitchLib.Client
                     break;
                 case MsgIds.MsgRateLimit:
                     OnRateLimit?.Invoke(this, new OnRateLimitArgs { Channel = ircMessage.Channel, Message = ircMessage.Message });
+                    break;
+                case MsgIds.MsgDuplicate:
+                    OnDuplicate?.Invoke(this, new OnDuplicateArgs { Channel = ircMessage.Channel, Message = ircMessage.Message });
                     break;
                 default:
                     OnUnaccountedFor?.Invoke(this, new OnUnaccountedForArgs { BotUsername = TwitchUsername, Channel = ircMessage.Channel, Location = "NoticeHandling", RawIRC = ircMessage.ToString() });

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -395,6 +395,11 @@ namespace TwitchLib.Client
         public event EventHandler<OnRequiresVerifiedPhoneNumberArgs> OnRequiresVerifiedPhoneNumber;
 
         /// <summary>
+        /// Occurs when send message rate limit has been applied to the client in a specific channel by Twitch
+        /// </summary>
+        public event EventHandler<OnRateLimitArgs> OnRateLimit;
+
+        /// <summary>
         /// Occurs when chatting in a channel that the user is banned in bcs of an already banned alias with the same Email
         /// </summary>
         public event EventHandler<OnBannedEmailAliasArgs> OnBannedEmailAlias;
@@ -1215,6 +1220,9 @@ namespace TwitchLib.Client
                     break;
                 case MsgIds.VIPsSuccess:
                     OnVIPsReceived?.Invoke(this, new OnVIPsReceivedArgs { Channel = ircMessage.Channel, VIPs = ircMessage.Message.Replace(" ", "").Replace(".", "").Split(':')[1].Split(',').ToList() });
+                    break;
+                case MsgIds.MsgRateLimit:
+                    OnRateLimit?.Invoke(this, new OnRateLimitArgs { Channel = ircMessage.Channel, Message = ircMessage.Message });
                     break;
                 default:
                     OnUnaccountedFor?.Invoke(this, new OnUnaccountedForArgs { BotUsername = TwitchUsername, Channel = ircMessage.Channel, Location = "NoticeHandling", RawIRC = ircMessage.ToString() });


### PR DESCRIPTION
This PR silently ignores capacity event messages, and adds support for eventing on rate limit and duplicate error messages from Twitch.

This is tested.