### PR TITLE
Fix IrcMessage parsing bug for (weird) 353 messages

### DIFF
--- a/TwitchLib.Client.Models/Internal/IrcMessage.cs
+++ b/TwitchLib.Client.Models/Internal/IrcMessage.cs
@@ -78,6 +78,14 @@ namespace TwitchLib.Client.Models.Internal
             _parameters = parameters;
             Command = command;
             Tags = tags;
+
+            if (command == IrcCommand.RPL_353)
+            {
+                if(Params.Length > 0 && Params.Contains("#"))
+                {
+                    _parameters[0] = $"#{_parameters[0].Split('#')[1]}";
+                }
+            }
         }
 
         public new string ToString()

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -1436,10 +1436,7 @@ namespace TwitchLib.Client
         /// <param name="ircMessage">The irc message.</param>
         private void Handle353(IrcMessage ircMessage)
         {
-            if (ircMessage.Message.Contains(" "))
-            {
-                OnExistingUsersDetected?.Invoke(this, new OnExistingUsersDetectedArgs { Channel = ircMessage.Channel, Users = ircMessage.Message.Split(' ').ToList() });
-            }
+            OnExistingUsersDetected?.Invoke(this, new OnExistingUsersDetectedArgs { Channel = ircMessage.Channel, Users = ircMessage.Message.Split(' ').ToList() });
         }
 
         /// <summary>

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -1436,7 +1436,7 @@ namespace TwitchLib.Client
         /// <param name="ircMessage">The irc message.</param>
         private void Handle353(IrcMessage ircMessage)
         {
-            if (string.Equals(ircMessage.Channel, TwitchUsername, StringComparison.InvariantCultureIgnoreCase))
+            if (ircMessage.Message.Contains(" "))
             {
                 OnExistingUsersDetected?.Invoke(this, new OnExistingUsersDetectedArgs { Channel = ircMessage.Channel, Users = ircMessage.Message.Split(' ').ToList() });
             }


### PR DESCRIPTION
353 irc messages are now parsed correctly.  The associated event (OnExistingUsersDetected) also fires as expected now. This issue was originally identified in 2019 by @Seeker1437 here: https://github.com/TwitchLib/TwitchLib/issues/436


Sample 353 message:
```
:swiftyspiffy.tmi.twitch.tv 353 swiftyspiffy = #burkeblack :jadrol mcober mr_perril naqeth bellolibr cjwprostar famousivan imshnaz limechaser neonenenderas noirmagic ruckinhell09 applessauces drunkennewbie knightofhamsters mrfancyrat nightleaf davethulhu ijustnt hostilebobcat kei_l limazulutango si_cwan strangedave streamelements ashbradford faps247 thetrufflebunny ussdefiant60 the_kraken_bot thenom mr_mio yvilion jollyman77 lordhh10 michael_angelo33 steelkreeg e2bm53 ikpeba
```

Tested and working. Also careful to apply this logic change *only* to 353 messages.