### PR TITLE
add IsFirstMessage property to ChatMessage model

### DIFF
--- a/TwitchLib.Client.Models/ChatMessage.cs
+++ b/TwitchLib.Client.Models/ChatMessage.cs
@@ -40,6 +40,9 @@ namespace TwitchLib.Client.Models
         /// <summary>Chat message from broadcaster identifier flag</summary>
         public bool IsBroadcaster { get; }
 
+        /// <summary>Chat message is the first message, ever, from this user in this chat</summary>
+        public bool IsFirstMessage { get; }
+
         /// <summary>Chat message is highlighted in chat via channel points</summary>
         public bool IsHighlighted { get; internal set; }
 
@@ -176,6 +179,9 @@ namespace TwitchLib.Client.Models
                         break;
                     case Tags.Emotes:
                         EmoteSet = new EmoteSet(tagValue, Message);
+                        break;
+                    case Tags.FirstMessage:
+                        IsFirstMessage = tagValue == "1";
                         break;
                     case Tags.Id:
                         Id = tagValue;

--- a/TwitchLib.Client.Models/Internal/Tags.cs
+++ b/TwitchLib.Client.Models/Internal/Tags.cs
@@ -14,6 +14,7 @@
         public const string Emotes = "emotes";
         public const string EmoteOnly = "emote-only";
         public const string EmotesSets = "emote-sets";
+        public const string FirstMessage = "first-msg";
         public const string Flags = "flags";
         public const string FollowersOnly = "followers-only";
         public const string Id = "id";


### PR DESCRIPTION
The First Time Chatter notification in chat is indicated by the `first-msg` irc parameter of the ChatMessage model. This PR adds a `IsFirstMessage` property to ChatMessage that reflects this value.

Sample IRC:
```
@badge-info=;badges=;client-nonce=20e793408e1413f915ee6442553792c0;color=;display-name=swiftyspiffyv5;emotes=;first-msg=1;flags=;id=166f5981-70dd-4d0a-b3f0-0e663aafd568;mod=0;room-id=723565395;subscriber=0;tmi-sent-ts=1639867328596;turbo=0;user-id=187514468;user-type= :swiftyspiffyv5!swiftyspiffyv5@swiftyspiffyv5.tmi.twitch.tv PRIVMSG #chonkology :test
```