### PR TITLE
Fixed joining Channel on IClient Reconnect()

### DIFF
--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -775,9 +775,6 @@ namespace TwitchLib.Client
         {
             if (!IsInitialized) HandleNotInitialized();
             Log($"Reconnecting to Twitch");
-            foreach (var channel in _joinedChannelManager.GetJoinedChannels())
-                _joinChannelQueue.Enqueue(channel);
-            _joinedChannelManager.Clear();
             _client.Reconnect();
         }
         #endregion
@@ -954,7 +951,6 @@ namespace TwitchLib.Client
         private void _client_OnDisconnected(object sender, OnDisconnectedEventArgs e)
         {
             OnDisconnected?.Invoke(sender, e);
-            _joinedChannelManager.Clear();
         }
 
         /// <summary>
@@ -964,6 +960,10 @@ namespace TwitchLib.Client
         /// <param name="e">The <see cref="OnReconnectedEventArgs" /> instance containing the event data.</param>
         private void _client_OnReconnected(object sender, OnReconnectedEventArgs e)
         {
+            foreach (var channel in _joinedChannelManager.GetJoinedChannels())
+                if(!string.Equals(channel.Channel, TwitchUsername, StringComparison.CurrentCultureIgnoreCase))
+                    _joinChannelQueue.Enqueue(channel);
+            _joinedChannelManager.Clear();
             OnReconnected?.Invoke(sender, e);
         }
 


### PR DESCRIPTION
While TwitchClient.Reconnect() currently joins all channels, it wont join all channel if the IClient only was reconencted. I moved adding the currently joined channel to the joining queue from Reconnect() to _client_OnReconnected() since the Reconnect() Methode calls the _client.Reconnect() methode which calls the _client_OnReconnected Event. To ensure that the BotAccount doesnt get joined twice, i check if it is not him and then add to the queue.

To get this work i need to remove the _joinedChannelManager.Clear() from _client_OnDisconnected since it gets deleted on the TwitchClient.Disconnect() Methode but stays if only the IClient gets disconnected to ensure it can be queued again after the reconnect.