### PR TITLE
Fixes a comment typo in ChannelState.cs

### DIFF
--- a/TwitchLib.Client.Models/ChannelState.cs
+++ b/TwitchLib.Client.Models/ChannelState.cs
@@ -28,7 +28,7 @@ namespace TwitchLib.Client.Models
         /// <summary>Property representing whether Rituals is enabled or not. WILL BE NULL IF VALUE NOT PRESENT.</summary>
         public bool? Rituals { get; }
 
-        /// <summary>Twitch assignedc room id</summary>
+        /// <summary>Twitch assigned room id</summary>
         public string RoomId { get; }
 
         /// <summary>Property representing whether Slow mode is being applied to chat or not. WILL BE NULL IF VALUE NOT PRESENT.</summary>


### PR DESCRIPTION
Fixes a small typo of a comment in ChannelState.cs ['assignedc' > 'assigned'](https://github.com/TwitchLib/TwitchLib.Client/blob/master/TwitchLib.Client.Models/ChannelState.cs#L31).