### PR TITLE
Add null check to TwitchClient::Initialize

### DIFF
--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -472,7 +472,7 @@ namespace TwitchLib.Client
         /// <param name="autoReListenOnExceptions">By default, TwitchClient will silence exceptions and auto-relisten for overall stability. For debugging, you may wish to have the exception bubble up, set this to false.</param>
         public void Initialize(ConnectionCredentials credentials, string channel = null, char chatCommandIdentifier = '!', char whisperCommandIdentifier = '!', bool autoReListenOnExceptions = true)
         {
-            if (channel[0] == '#') channel = channel.Substring(1);
+            if (channel != null && channel[0] == '#') channel = channel.Substring(1);
             initializeHelper(credentials, new List<string>() { channel }, chatCommandIdentifier, whisperCommandIdentifier, autoReListenOnExceptions);
         }
 


### PR DESCRIPTION
If the 'channel' parameter is null in the TwitchClient::Initialize method, the application will crash with a NullReferenceException. This is due to a recently added check in https://github.com/TwitchLib/TwitchLib.Client/pull/201 . This does not seem intended as the default value for channel is null, hence this quick check.