### PR TITLE
Allow '-1' to indicate Followers-Only mode is switched off

### DIFF
--- a/TwitchLib.Client.Models/ChannelState.cs
+++ b/TwitchLib.Client.Models/ChannelState.cs
@@ -16,7 +16,7 @@ namespace TwitchLib.Client.Models
         /// <summary>Property representing whether EmoteOnly mode is being applied to chat or not. WILL BE NULL IF VALUE NOT PRESENT.</summary>
         public bool? EmoteOnly { get; }
 
-        /// <summary>Property representing how long needed to be following to talk. TimeSpan.MinValue indicates that FollowersOnly mode is switched off, If null, FollowersOnly is not enabled.</summary>
+        /// <summary>Property representing how long needed to be following to talk. TimeSpan.MinValue indicates that FollowersOnly mode is switched off, If null, FollowersOnly status is not changed.</summary>
         public TimeSpan? FollowersOnly { get; } = null;
 
         /// <summary>Property representing mercury value. Not sure what it's for.</summary>

--- a/TwitchLib.Client.Models/ChannelState.cs
+++ b/TwitchLib.Client.Models/ChannelState.cs
@@ -16,7 +16,7 @@ namespace TwitchLib.Client.Models
         /// <summary>Property representing whether EmoteOnly mode is being applied to chat or not. WILL BE NULL IF VALUE NOT PRESENT.</summary>
         public bool? EmoteOnly { get; }
 
-        /// <summary>Property representing how long needed to be following to talk. If null, FollowersOnly is not enabled.</summary>
+        /// <summary>Property representing how long needed to be following to talk. TimeSpan.MinValue indicates that FollowersOnly mode is switched off, If null, FollowersOnly is not enabled.</summary>
         public TimeSpan? FollowersOnly { get; } = null;
 
         /// <summary>Property representing mercury value. Not sure what it's for.</summary>
@@ -67,9 +67,9 @@ namespace TwitchLib.Client.Models
                         SubOnly = Common.Helpers.ConvertToBool(tagValue);
                         break;
                     case Tags.FollowersOnly:
-                        if(int.TryParse(tagValue, out int minutes) && minutes > -1)
+                        if(int.TryParse(tagValue, out int minutes))
                         {
-                            FollowersOnly = TimeSpan.FromMinutes(minutes);
+                            FollowersOnly = minutes > -1 ? TimeSpan.FromMinutes(minutes) : TimeSpan.MinValue;
                         }
                         break;
                     case Tags.RoomId:


### PR DESCRIPTION
FollowersOnly field will take TimeSpan.MinValue when Followers-only mode is switched off.
Fixes issue #207 