### PR TITLE
Tweak logging to have logical levels instead of logging everything as Information.

### DIFF
--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -498,7 +498,7 @@ namespace TwitchLib.Client
         /// <param name="autoReListenOnExceptions">By default, TwitchClient will silence exceptions and auto-relisten for overall stability. For debugging, you may wish to have the exception bubble up, set this to false.</param>
         private void initializeHelper(ConnectionCredentials credentials, List<string> channels, char chatCommandIdentifier = '!', char whisperCommandIdentifier = '!', bool autoReListenOnExceptions = true)
         {
-            Log($"TwitchLib-TwitchClient initialized, assembly version: {Assembly.GetExecutingAssembly().GetName().Version}");
+            Log($"TwitchLib-TwitchClient initialized, assembly version: {Assembly.GetExecutingAssembly().GetName().Version}", level: LogLevel.Information);
             ConnectionCredentials = credentials;
             TwitchUsername = ConnectionCredentials.TwitchUsername;
             if (chatCommandIdentifier != '\0')
@@ -695,7 +695,7 @@ namespace TwitchLib.Client
         public bool Connect()
         {
             if (!IsInitialized) HandleNotInitialized();
-            Log($"Connecting to: {ConnectionCredentials.TwitchWebsocketURI}");
+            Log($"Connecting to: {ConnectionCredentials.TwitchWebsocketURI}", level: LogLevel.Information);
 
 			// Clear instance data
             _joinedChannelManager.Clear();
@@ -713,7 +713,7 @@ namespace TwitchLib.Client
         /// </summary>
         public void Disconnect()
         {
-            Log("Disconnect Twitch Chat Client...");
+            Log("Disconnecting Twitch Chat Client...", level: LogLevel.Information);
 
             if (!IsInitialized) HandleNotInitialized();
             _client.Close();
@@ -729,7 +729,7 @@ namespace TwitchLib.Client
         public void Reconnect()
         {
             if (!IsInitialized) HandleNotInitialized();
-            Log($"Reconnecting to Twitch");
+            Log($"Reconnecting to Twitch", level: LogLevel.Information);
             _client.Reconnect();
         }
         #endregion
@@ -837,7 +837,7 @@ namespace TwitchLib.Client
             if (!IsInitialized) HandleNotInitialized();
             // Channel MUST be lower case
             channel = channel.ToLower();
-            Log($"Leaving channel: {channel}");
+            Log($"Leaving channel: {channel}", level: LogLevel.Information);
             JoinedChannel joinedChannel = _joinedChannelManager.GetJoinedChannel(channel);
             if (joinedChannel != null)
                 _client.Send(Rfc2812.Part($"#{channel}"));
@@ -936,7 +936,7 @@ namespace TwitchLib.Client
                 if (line.Length <= 1)
                     continue;
 
-                Log($"Received: {line}");
+                Log($"Received: {line}", level: LogLevel.Trace);
                 OnSendReceiveData?.Invoke(this, new OnSendReceiveDataArgs { Direction = Enums.SendReceiveDirection.Received, Data = line });
                 HandleIrcMessage(_ircParser.ParseIrcMessage(line));
             }
@@ -979,7 +979,7 @@ namespace TwitchLib.Client
             {
                 _currentlyJoiningChannels = true;
                 JoinedChannel channelToJoin = _joinChannelQueue.Dequeue();
-                Log($"Joining channel: {channelToJoin.Channel}");
+                Log($"Joining channel: {channelToJoin.Channel}", level: LogLevel.Information);
                 // important we set channel to lower case when sending join message
                 _client.Send(Rfc2812.Join($"#{channelToJoin.Channel.ToLower()}"));
                 _joinedChannelManager.AddJoinedChannel(new JoinedChannel(channelToJoin.Channel));
@@ -1491,7 +1491,7 @@ namespace TwitchLib.Client
 
         private void UnaccountedFor(string ircString)
         {
-            Log($"Unaccounted for: {ircString} (please create a TwitchLib GitHub issue :P)");
+            Log($"Unaccounted for: {ircString} (please create a TwitchLib GitHub issue :P)", level: LogLevel.Warning);
         }
 
         /// <summary>
@@ -1500,7 +1500,8 @@ namespace TwitchLib.Client
         /// <param name="message">The message.</param>
         /// <param name="includeDate">if set to <c>true</c> [include date].</param>
         /// <param name="includeTime">if set to <c>true</c> [include time].</param>
-        private void Log(string message, bool includeDate = false, bool includeTime = false)
+        /// <param name="level">The log level of the message.</param>
+        private void Log(string message, bool includeDate = false, bool includeTime = false, LogLevel level = LogLevel.Debug)
         {
             string dateTimeStr;
             if (includeDate && includeTime)
@@ -1511,9 +1512,9 @@ namespace TwitchLib.Client
                 dateTimeStr = $"{DateTime.UtcNow.ToShortTimeString()}";
 
             if (includeDate || includeTime)
-                _logger?.LogInformation($"[TwitchLib, {Assembly.GetExecutingAssembly().GetName().Version} - {dateTimeStr}] {message}");
+                _logger?.Log(level, $"[TwitchLib, {Assembly.GetExecutingAssembly().GetName().Version} - {dateTimeStr}] {message}");
             else
-                _logger?.LogInformation($"[TwitchLib, {Assembly.GetExecutingAssembly().GetName().Version}] {message}");
+                _logger?.Log(level, $"[TwitchLib, {Assembly.GetExecutingAssembly().GetName().Version}] {message}");
 
             OnLog?.Invoke(this, new OnLogArgs { BotUsername = ConnectionCredentials?.TwitchUsername, Data = message, DateTime = DateTime.UtcNow });
         }

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -837,6 +837,7 @@ namespace TwitchLib.Client
             if (!IsInitialized) HandleNotInitialized();
             // Channel MUST be lower case
             channel = channel.ToLower();
+            if (channel[0] == '#') channel = channel.Substring(1);
             Log($"Leaving channel: {channel}", level: LogLevel.Information);
             JoinedChannel joinedChannel = _joinedChannelManager.GetJoinedChannel(channel);
             if (joinedChannel != null)


### PR DESCRIPTION
TwitchLib currently logs everything with the 'Information' level, which is HORRIBLE for anyone adding a logger. Not only does it blast you with logs that are (99% of the time) useless, but it also makes it impossible to see what you're logging in your actual code.

Any channel that averages 100+ viewers will have your console looking like this: 
![image](https://user-images.githubusercontent.com/69414142/219636816-1cdd32e6-2440-4f91-9da6-57e393b43641.png)
Every few seconds as membership joins are received from IRC your console will be filled with these logs, hiding anything useful that you would want to see.

This PR aims to address this issue, by logging things with their relevant levels; I have added an additional optional parameter to the Log() method, which allows setting the logging level.