### PR TITLE
Create .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "TwitchLib.Communication"]
+	path = TwitchLib.Communication
+	url = https://github.com/TwitchLib/TwitchLib.Communication


### PR DESCRIPTION
Currently .gitmodules is missing from this repo. This creates a link breakage when trying to clone/build the main project https://github.com/TwitchLib/TwitchLib in one shot with the 
```
git submodule update --init --recursive --remote --merge
```
command


I do however notice that in https://github.com/TwitchLib/TwitchLib.Client/commit/74e1a61482cfe2c9bcf8436011f56a540af9f7d7
Something is mentioned about submodule removal for 
```
CI Preparation work.
```

Feel free to dismiss this PR if this change is unnecessary, or unwarranted, I just wanted to try to help others who may try to clone/build this in the future