### PR TITLE
remove unnecessary 'unaccounted for' in `HandleWhisper`

### DIFF
--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -1384,10 +1384,7 @@ namespace TwitchLib.Client
                 {
                     WhisperCommand whisperCommand = new WhisperCommand(whisperMessage);
                     OnWhisperCommandReceived?.Invoke(this, new OnWhisperCommandReceivedArgs { Command = whisperCommand });
-                    return;
                 }
-            OnUnaccountedFor?.Invoke(this, new OnUnaccountedForArgs { BotUsername = TwitchUsername, Channel = ircMessage.Channel, Location = "WhispergHandling", RawIRC = ircMessage.ToString() });
-            UnaccountedFor(ircMessage.ToString());
         }
 
         /// <summary>


### PR DESCRIPTION
This seems to have always been a bit nonsensical,
but it became more visible after 1c397a4a6aa53677f53c27e9d9aa101afb90ff36 since the log level is now Warning