### PR TITLE
improve logging performance

### DIFF
--- a/TwitchLib.Client.Models/Builders/ConnectionCredentialsBuilder.cs
+++ b/TwitchLib.Client.Models/Builders/ConnectionCredentialsBuilder.cs
@@ -4,7 +4,6 @@
     {
         private string _twitchUsername;
         private string _twitchOAuth;
-        private string _twitchWebsocketURI = ConnectionCredentials.DefaultWebSocketUri;
         private bool _disableUsernameCheck;
 
         private ConnectionCredentialsBuilder()
@@ -20,12 +19,6 @@
         public ConnectionCredentialsBuilder WithTwitchOAuth(string twitchOAuth)
         {
             _twitchOAuth = twitchOAuth;
-            return this;
-        }
-
-        public ConnectionCredentialsBuilder WithTwitchWebSocketUri(string twitchWebSocketUri)
-        {
-            _twitchWebsocketURI = twitchWebSocketUri;
             return this;
         }
 
@@ -45,7 +38,6 @@
             return new ConnectionCredentials(
                 _twitchUsername,
                 _twitchOAuth,
-                twitchWebsocketURI: _twitchWebsocketURI,
                 disableUsernameCheck: _disableUsernameCheck);
         }
     }

--- a/TwitchLib.Client.Models/ConnectionCredentials.cs
+++ b/TwitchLib.Client.Models/ConnectionCredentials.cs
@@ -6,11 +6,6 @@ namespace TwitchLib.Client.Models
     /// <summary>Class used to store credentials used to connect to Twitch chat/whisper.</summary>
     public class ConnectionCredentials
     {
-        public const string DefaultWebSocketUri = "wss://irc-ws.chat.twitch.tv:443";
-
-        /// <summary>Property representing URI used to connect to Twitch websocket service.</summary>
-        public string TwitchWebsocketURI { get; }
-
         /// <summary>Property representing bot's oauth.</summary>
         public string TwitchOAuth { get; }
 
@@ -24,7 +19,6 @@ namespace TwitchLib.Client.Models
         public ConnectionCredentials(
             string twitchUsername,
             string twitchOAuth,
-            string twitchWebsocketURI = DefaultWebSocketUri,
             bool disableUsernameCheck = false,
             Capabilities capabilities = null)
         {
@@ -39,8 +33,6 @@ namespace TwitchLib.Client.Models
             {
                 TwitchOAuth = $"oauth:{twitchOAuth.Replace("oauth", "")}";
             }
-
-            TwitchWebsocketURI = twitchWebsocketURI;
 
             if (capabilities == null)
                 capabilities = new Capabilities();

--- a/TwitchLib.Client/Extensions/LogExtensions.cs
+++ b/TwitchLib.Client/Extensions/LogExtensions.cs
@@ -6,42 +6,42 @@ namespace TwitchLib.Client.Extensions;
 
 internal static partial class LogExtensions
 {
-    [LoggerMessage(-1, LogLevel.Information, "Connecting Twitch Chat Client...")]
+    [LoggerMessage(0, LogLevel.Information, "Connecting Twitch Chat Client...")]
     public static partial void LogConnecting(this ILogger<TwitchClient> logger);
 
-    [LoggerMessage(-1, LogLevel.Information, "Disconnecting Twitch Chat Client...")]
+    [LoggerMessage(0, LogLevel.Information, "Disconnecting Twitch Chat Client...")]
     public static partial void LogDisconnecting(this ILogger<TwitchClient> logger);
 
-    [LoggerMessage(-1, LogLevel.Information, "TwitchLib-TwitchClient initialized, assembly version: {version}")]
+    [LoggerMessage(0, LogLevel.Information, "TwitchLib-TwitchClient initialized, assembly version: {version}")]
     public static partial void LogInitialized(this ILogger<TwitchClient> logger, Version version);
 
-    [LoggerMessage(-1, LogLevel.Information, "Joining channel: {channel}")]
+    [LoggerMessage(0, LogLevel.Information, "Joining channel: {channel}")]
     public static partial void LogJoiningChannel(this ILogger<TwitchClient> logger, string channel);
 
-    [LoggerMessage(-1, LogLevel.Debug, "Finished channel joining queue.")]
+    [LoggerMessage(0, LogLevel.Debug, "Finished channel joining queue.")]
     public static partial void LogChannelJoiningFinished(this ILogger<TwitchClient> logger);
 
-    [LoggerMessage(-1, LogLevel.Information, "Leaving channel: {channel}")]
+    [LoggerMessage(0, LogLevel.Information, "Leaving channel: {channel}")]
     public static partial void LogLeavingChannel(this ILogger<TwitchClient> logger, string channel);
 
-    [LoggerMessage(-1, LogLevel.Error, "Message length has exceeded the maximum character count. (500)")]
+    [LoggerMessage(0, LogLevel.Error, "Message length has exceeded the maximum character count. (500)")]
     public static partial void LogMessageTooLong(this ILogger<TwitchClient> logger);
 
-    [LoggerMessage(-1, LogLevel.Trace, "Received: {line}")]
+    [LoggerMessage(0, LogLevel.Trace, "Received: {line}")]
     public static partial void LogReceived(this ILogger<TwitchClient> logger, string line);
 
-    [LoggerMessage(-1, LogLevel.Information, "Reconnecting to Twitch")]
+    [LoggerMessage(0, LogLevel.Information, "Reconnecting to Twitch")]
     public static partial void LogReconnecting(this ILogger<TwitchClient> logger);
 
-    [LoggerMessage(-1, LogLevel.Debug, "Should be connected!")]
+    [LoggerMessage(0, LogLevel.Debug, "Should be connected!")]
     public static partial void LogShouldBeConnected(this ILogger<TwitchClient> logger);
 
-    [LoggerMessage(-1, LogLevel.Warning, "Unaccounted for: {ircString} (please create a TwitchLib GitHub issue :P)")]
+    [LoggerMessage(0, LogLevel.Warning, "Unaccounted for: {ircString} (please create a TwitchLib GitHub issue :P)")]
     public static partial void LogUnaccountedFor(this ILogger<TwitchClient> logger, string ircString);
 
-    [LoggerMessage(-1, LogLevel.Debug, "Writing: {message}")]
+    [LoggerMessage(0, LogLevel.Debug, "Writing: {message}")]
     public static partial void LogWriting(this ILogger<TwitchClient> logger, string message);
 
-    [LoggerMessage(-1, LogLevel.Error, "{message}")]
+    [LoggerMessage(0, LogLevel.Error, "{message}")]
     public static partial void LogException(this ILogger logger, string message, Exception ex);
 }

--- a/TwitchLib.Client/Extensions/LogExtensions.cs
+++ b/TwitchLib.Client/Extensions/LogExtensions.cs
@@ -1,0 +1,47 @@
+﻿#pragma warning disable SYSLIB1006 // Multiple logging methods cannot use the same event id within a class
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace TwitchLib.Client.Extensions;
+
+internal static partial class LogExtensions
+{
+    [LoggerMessage(-1, LogLevel.Information, "Connecting Twitch Chat Client...")]
+    public static partial void LogConnecting(this ILogger<TwitchClient> logger);
+
+    [LoggerMessage(-1, LogLevel.Information, "Disconnecting Twitch Chat Client...")]
+    public static partial void LogDisconnecting(this ILogger<TwitchClient> logger);
+
+    [LoggerMessage(-1, LogLevel.Information, "TwitchLib-TwitchClient initialized, assembly version: {version}")]
+    public static partial void LogInitialized(this ILogger<TwitchClient> logger, Version version);
+
+    [LoggerMessage(-1, LogLevel.Information, "Joining channel: {channel}")]
+    public static partial void LogJoiningChannel(this ILogger<TwitchClient> logger, string channel);
+
+    [LoggerMessage(-1, LogLevel.Debug, "Finished channel joining queue.")]
+    public static partial void LogChannelJoiningFinished(this ILogger<TwitchClient> logger);
+
+    [LoggerMessage(-1, LogLevel.Information, "Leaving channel: {channel}")]
+    public static partial void LogLeavingChannel(this ILogger<TwitchClient> logger, string channel);
+
+    [LoggerMessage(-1, LogLevel.Error, "Message length has exceeded the maximum character count. (500)")]
+    public static partial void LogMessageTooLong(this ILogger<TwitchClient> logger);
+
+    [LoggerMessage(-1, LogLevel.Trace, "Received: {line}")]
+    public static partial void LogReceived(this ILogger<TwitchClient> logger, string line);
+
+    [LoggerMessage(-1, LogLevel.Information, "Reconnecting to Twitch")]
+    public static partial void LogReconnecting(this ILogger<TwitchClient> logger);
+
+    [LoggerMessage(-1, LogLevel.Debug, "Should be connected!")]
+    public static partial void LogShouldBeConnected(this ILogger<TwitchClient> logger);
+
+    [LoggerMessage(-1, LogLevel.Warning, "Unaccounted for: {ircString} (please create a TwitchLib GitHub issue :P)")]
+    public static partial void LogUnaccountedFor(this ILogger<TwitchClient> logger, string ircString);
+
+    [LoggerMessage(-1, LogLevel.Debug, "Writing: {message}")]
+    public static partial void LogWriting(this ILogger<TwitchClient> logger, string message);
+
+    [LoggerMessage(-1, LogLevel.Error, "{message}")]
+    public static partial void LogException(this ILogger logger, string message, Exception ex);
+}

--- a/TwitchLib.Client/Interfaces/ITwitchClient.cs
+++ b/TwitchLib.Client/Interfaces/ITwitchClient.cs
@@ -111,10 +111,6 @@ namespace TwitchLib.Client.Interfaces
         /// </summary>
         event EventHandler<OnLeftChannelArgs> OnLeftChannel;
         /// <summary>
-        /// Occurs when [on log].
-        /// </summary>
-        event EventHandler<OnLogArgs> OnLog;
-        /// <summary>
         /// Occurs when [on message received].
         /// </summary>
         event EventHandler<OnMessageReceivedArgs> OnMessageReceived;

--- a/TwitchLib.Client/Throttling/ThrottlingService.cs
+++ b/TwitchLib.Client/Throttling/ThrottlingService.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using TwitchLib.Client.Events;
+using TwitchLib.Client.Extensions;
 using TwitchLib.Client.Internal;
 using TwitchLib.Client.Models;
 using TwitchLib.Client.Models.Interfaces;
@@ -130,7 +131,7 @@ namespace TwitchLib.Client.Throttling
             }
             catch (Exception ex)
             {
-                _logger?.LogError(ex.ToString());
+                _logger?.LogException(ex);
                 _client.RaiseEvent(nameof(_client.OnError), new OnErrorEventArgs(ex));
             }
         }

--- a/TwitchLib.Client/Throttling/ThrottlingService.cs
+++ b/TwitchLib.Client/Throttling/ThrottlingService.cs
@@ -131,7 +131,7 @@ namespace TwitchLib.Client.Throttling
             }
             catch (Exception ex)
             {
-                _logger?.LogException(ex);
+                _logger?.LogException(ex.Message, ex);
                 _client.RaiseEvent(nameof(_client.OnError), new OnErrorEventArgs(ex));
             }
         }

--- a/TwitchLib.Client/TwitchLib.Client.csproj
+++ b/TwitchLib.Client/TwitchLib.Client.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
-    <PackageReference Include="TwitchLib.Communication" Version="2.0.0-preview-05aa112a5af2b9a07f5b828b7ebe333582df0c32" />
+    <PackageReference Include="TwitchLib.Communication" Version="2.0.0-preview-8108207851b6bbef87062f15a497036183ffea70" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TwitchLib.Client.Enums\TwitchLib.Client.Enums.csproj" />


### PR DESCRIPTION
- Better logging
- removed unused property `TwitchWebsocketURI`
- `TwitchClient` now accepts `ILoggerFactory` instead of `ILogger<TwitchClient>` so logging for `TcpClient`/`WebSocketClient` is now enabled by default