### PR TITLE
Missing handshake and joining channel on reconnect fix

### DIFF
--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -998,10 +998,7 @@ namespace TwitchLib.Client
 
             foreach (var channel in _joinedChannelManager.GetJoinedChannels())
             {
-                if (!string.Equals(channel.Channel, TwitchUsername, StringComparison.CurrentCultureIgnoreCase))
-                {
-                    _joinChannelQueue.Enqueue(channel);
-                }
+                _joinChannelQueue.Enqueue(channel);
             }
 
             if(_joinChannelQueue != null && _joinChannelQueue.Count > 0)


### PR DESCRIPTION
The Twitch handshake on the reconnect was missing. Because of that, Twitch closed the connection to the client resulting in being unable to reconnect. Also the joining of the channels was missing.

Since the TwitchUsername (from the Credentials) isn't automatically joined, it doesn't need to check whether the channel is not the TwitchUsername.