### PR TITLE
Fix `MessageEmoteCollection` + additional fixes/improvements

### DIFF
--- a/TwitchLib.Client.Benchmark/ChatMessage.cs
+++ b/TwitchLib.Client.Benchmark/ChatMessage.cs
@@ -1,0 +1,22 @@
+using BenchmarkDotNet.Attributes;
+using TwitchLib.Client.Internal.Parsing;
+using TwitchLib.Client.Models;
+using TwitchLib.Client.Models.Internal;
+
+namespace TwitchLib.Client.Benchmark
+{
+    [ShortRunJob, MemoryDiagnoser]
+    public class ChatMessageBenchmark
+    {
+        private static readonly IrcMessage Message = IrcParser.ParseMessage(
+            "@badge-info=subscriber/22;badges=subscriber/3012;color=#FFFF00;display-name=FELYP8;emote-only=1;emotes=521050:0-6,8-14,16-22,24-30,32-38,40-46,48-54,56-62,64-70,72-78,80-86,88-94,96-102,104-110,148-154,156-162,164-170,172-178,180-186,188-194,196-202,204-210,212-218,220-226,228-234,236-242,244-250,252-258,260-266/302827730:112-119/302827734:121-128/302827735:130-137/302827737:139-146;first-msg=0;flags=;id=1844235a-c24e-4e18-937b-805d6601aebe;mod=0;returning-chatter=0;room-id=22484632;subscriber=1;tmi-sent-ts=1685664001040;turbo=0;user-id=162760707;user-type= :felyp8!felyp8@felyp8.tmi.twitch.tv PRIVMSG #forsen :forsenE forsenE forsenE forsenE forsenE forsenE forsenE forsenE forsenE forsenE forsenE forsenE forsenE forsenE forsenE1 forsenE2 forsenE3 forsenE4 forsenE forsenE forsenE forsenE forsenE forsenE forsenE forsenE forsenE forsenE forsenE forsenE forsenE forsenE forsenE");
+
+        private readonly MessageEmoteCollection ChannelEmotes = new();
+
+        [Benchmark]
+        public ChatMessage ClientScenarioCreate()
+        {
+            return new("test_name", Message, ChannelEmotes);
+        }
+    }
+}

--- a/TwitchLib.Client.Models/ChatMessage.cs
+++ b/TwitchLib.Client.Models/ChatMessage.cs
@@ -96,7 +96,7 @@ namespace TwitchLib.Client.Models
         public ChatMessage(
             string botUsername,
             IrcMessage ircMessage,
-            ref MessageEmoteCollection emoteCollection,
+            MessageEmoteCollection emoteCollection,
             bool replaceEmotes = false,
             string prefix = "",
             string suffix = "")

--- a/TwitchLib.Client.Models/ChatMessage.cs
+++ b/TwitchLib.Client.Models/ChatMessage.cs
@@ -317,13 +317,11 @@ namespace TwitchLib.Client.Models
             }
 
             var splitData = Channel.Split(':');
-            if (splitData.Length == 3)
+            if (splitData.Length == 3 &&
+                string.Equals(splitData[1], UserId, StringComparison.InvariantCultureIgnoreCase))
             {
-                if (string.Equals(splitData[1], UserId, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    UserType = UserType.Broadcaster;
-                    IsBroadcaster = true;
-                }
+                UserType = UserType.Broadcaster;
+                IsBroadcaster = true;
             }
         }
 

--- a/TwitchLib.Client.Models/ChatMessage.cs
+++ b/TwitchLib.Client.Models/ChatMessage.cs
@@ -96,7 +96,7 @@ namespace TwitchLib.Client.Models
         public ChatMessage(
             string botUsername,
             IrcMessage ircMessage,
-            MessageEmoteCollection emoteCollection,
+            MessageEmoteCollection emoteCollection = null,
             bool replaceEmotes = false,
             string prefix = "",
             string suffix = "")
@@ -123,11 +123,10 @@ namespace TwitchLib.Client.Models
             Username = ircMessage.User;
             Channel = ircMessage.Channel;
 
-            foreach (var tag in ircMessage.Tags.Keys)
+            foreach (var tag in ircMessage.Tags)
             {
-                var tagValue = ircMessage.Tags[tag];
-
-                switch (tag)
+                var (tagKey, tagValue) = (tag.Key, tag.Value);
+                switch (tagKey)
                 {
                     case Tags.Badges:
                         Badges = Common.Helpers.ParseBadges(tagValue);
@@ -141,7 +140,7 @@ namespace TwitchLib.Client.Models
                                     break;
                                 case "subscriber":
                                     // Prioritize BadgeInfo subscribe count, as its more accurate
-                                    if(SubscribedMonthCount == 0)
+                                    if (SubscribedMonthCount == 0)
                                     {
                                         SubscribedMonthCount = int.Parse(badge.Value);
                                     }
@@ -150,15 +149,12 @@ namespace TwitchLib.Client.Models
                                     IsVip = true;
                                     break;
                                 case "admin":
-                                    IsStaff = true;
-                                    break;
                                 case "staff":
                                     IsStaff = true;
                                     break;
                                 case "partner":
                                     IsPartner = true;
                                     break;
-
                             }
                         }
                         break;
@@ -166,11 +162,12 @@ namespace TwitchLib.Client.Models
                         BadgeInfo = Common.Helpers.ParseBadges(tagValue);
                         // check if founder is one of them, and get months from that
                         var founderBadge = BadgeInfo.Find(b => b.Key == "founder");
-                        if(!founderBadge.Equals(default(KeyValuePair<string, string>)))
+                        if (!founderBadge.Equals(default(KeyValuePair<string, string>)))
                         {
                             IsSubscriber = true;
                             SubscribedMonthCount = int.Parse(founderBadge.Value);
-                        } else
+                        }
+                        else
                         {
                             var subBadge = BadgeInfo.Find(b => b.Key == "subscriber");
                             // BadgeInfo has better accuracy than Badges subscriber value
@@ -205,7 +202,7 @@ namespace TwitchLib.Client.Models
                         Id = tagValue;
                         break;
                     case Tags.MsgId:
-                        handleMsgId(tagValue);
+                        HandleMsgId(tagValue);
                         break;
                     case Tags.Mod:
                         IsModerator = Common.Helpers.ConvertToBool(tagValue);
@@ -214,23 +211,23 @@ namespace TwitchLib.Client.Models
                         Noisy = Common.Helpers.ConvertToBool(tagValue) ? Noisy.True : Noisy.False;
                         break;
                     case Tags.ReplyParentDisplayName:
-                        if (ChatReply == null) { ChatReply = new ChatReply(); } // ChatReply is null if not reply
+                        ChatReply ??= new ChatReply(); // ChatReply is null if not reply
                         ChatReply.ParentDisplayName = tagValue;
                         break;
                     case Tags.ReplyParentMsgBody:
-                        if (ChatReply == null) { ChatReply = new ChatReply(); } // ChatReply is null if not reply
+                        ChatReply ??= new ChatReply(); // ChatReply is null if not reply
                         ChatReply.ParentMsgBody = tagValue;
                         break;
                     case Tags.ReplyParentMsgId:
-                        if (ChatReply == null) { ChatReply = new ChatReply(); } // ChatReply is null if not reply
+                        ChatReply ??= new ChatReply(); // ChatReply is null if not reply
                         ChatReply.ParentMsgId = tagValue;
                         break;
                     case Tags.ReplyParentUserId:
-                        if (ChatReply == null) { ChatReply = new ChatReply(); } // ChatReply is null if not reply
+                        ChatReply ??= new ChatReply(); // ChatReply is null if not reply
                         ChatReply.ParentUserId = tagValue;
                         break;
                     case Tags.ReplyParentUserLogin:
-                        if (ChatReply == null) { ChatReply = new ChatReply(); } // ChatReply is null if not reply
+                        ChatReply ??= new ChatReply(); // ChatReply is null if not reply
                         ChatReply.ParentUserLogin = tagValue;
                         break;
                     case Tags.RoomId:
@@ -238,7 +235,7 @@ namespace TwitchLib.Client.Models
                         break;
                     case Tags.Subscriber:
                         // this check because when founder is set, the subscriber value is actually 0, which is problematic
-                        IsSubscriber = IsSubscriber == false ? Common.Helpers.ConvertToBool(tagValue) : true;
+                        IsSubscriber = IsSubscriber || Common.Helpers.ConvertToBool(tagValue);
                         break;
                     case Tags.TmiSentTs:
                         TmiSentTs = tagValue;
@@ -275,7 +272,7 @@ namespace TwitchLib.Client.Models
             }
 
             //Parse the emoteSet
-            if (EmoteSet != null && Message != null && EmoteSet.Emotes.Count > 0)
+            if (_emoteCollection != null && Message != null && EmoteSet?.Emotes.Count > 0)
             {
                 var uniqueEmotes = EmoteSet.RawEmoteSetString.Split('/');
                 foreach (var emote in uniqueEmotes)
@@ -302,12 +299,11 @@ namespace TwitchLib.Client.Models
                 }
                 if (replaceEmotes)
                 {
-                    EmoteReplacedMessage = _emoteCollection.ReplaceEmotes(originalMessage: Message,suffix: suffix,prefix: prefix);
+                    EmoteReplacedMessage = _emoteCollection?.ReplaceEmotes(Message, prefix: prefix, suffix: suffix);
                 }
             }
 
-            if (EmoteSet == null)
-                EmoteSet = new EmoteSet(default(string), Message);
+            EmoteSet ??= new EmoteSet(default(string), Message);
 
             // Check if display name was set, and if it wasn't, set it to username
             if (string.IsNullOrEmpty(DisplayName))
@@ -380,7 +376,7 @@ namespace TwitchLib.Client.Models
             IsBroadcaster = isBroadcaster;
             IsVip = isVip;
             IsPartner = isPartner;
-            IsStaff = isStaff; 
+            IsStaff = isStaff;
             Noisy = noisy;
             RawIrcMessage = rawIrcMessage;
             EmoteReplacedMessage = emoteReplacedMessage;
@@ -391,15 +387,15 @@ namespace TwitchLib.Client.Models
             Username = userName;
         }
 
-        private void handleMsgId(string val)
+        private void HandleMsgId(string val)
         {
-            switch(val) {
-                case MsgIds.HighlightedMessage:
-                    IsHighlighted = true;
-                    break;
-                case MsgIds.SkipSubsModeMessage:
-                    IsSkippingSubMode = true;
-                    break;
+            if (val == MsgIds.HighlightedMessage)
+            {
+                IsHighlighted = true;
+            }
+            else if (val == MsgIds.SkipSubsModeMessage)
+            {
+                IsSkippingSubMode = true;
             }
         }
 
@@ -414,23 +410,14 @@ namespace TwitchLib.Client.Models
             10000 bits = $126.00 (10%)
             25000 bits = $308.00 (12%)
             */
-            if (bits < 1500)
+            return bits switch
             {
-                return (double)bits / 100 * 1.4;
-            }
-            if (bits < 5000)
-            {
-                return (double)bits / 1500 * 19.95;
-            }
-            if (bits < 10000)
-            {
-                return (double)bits / 5000 * 64.40;
-            }
-            if (bits < 25000)
-            {
-                return (double)bits / 10000 * 126;
-            }
-            return (double)bits / 25000 * 308;
+                < 1500 => (double)bits / 100 * 1.4,
+                < 5000 => (double)bits / 1500 * 19.95,
+                < 10000 => (double)bits / 5000 * 64.40,
+                < 25000 => (double)bits / 10000 * 126,
+                _ => (double)bits / 25000 * 308
+            };
         }
     }
 }

--- a/TwitchLib.Client.Models/Internal/IrcMessage.cs
+++ b/TwitchLib.Client.Models/Internal/IrcMessage.cs
@@ -93,7 +93,7 @@ namespace TwitchLib.Client.Models.Internal
         /// <summary>
         /// Create an IrcMessage, settings its raw string.
         /// IrcParser *must* use this constructor, otherwise the raw string
-        /// will be re-generated on each PRIVMSG (90% of all messages)
+        /// will be re-generated each time it is parsed and then passed to handlers.
         /// </summary>
         /// <param name="raw">Raw IRC message</param>
         /// <param name="command">IRC Command</param>

--- a/TwitchLib.Client/Events/OnExistingUsersDetectedArgs.cs
+++ b/TwitchLib.Client/Events/OnExistingUsersDetectedArgs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace TwitchLib.Client.Events
 {
@@ -13,7 +14,7 @@ namespace TwitchLib.Client.Events
         /// <summary>
         /// Property representing string list of existing users.
         /// </summary>
-        public string[] Users;
+        public List<string> Users;
         /// <summary>
         /// Property representing channel bot is connected to.
         /// </summary>

--- a/TwitchLib.Client/Events/OnExistingUsersDetectedArgs.cs
+++ b/TwitchLib.Client/Events/OnExistingUsersDetectedArgs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace TwitchLib.Client.Events
 {
@@ -14,7 +13,7 @@ namespace TwitchLib.Client.Events
         /// <summary>
         /// Property representing string list of existing users.
         /// </summary>
-        public List<string> Users;
+        public string[] Users;
         /// <summary>
         /// Property representing channel bot is connected to.
         /// </summary>

--- a/TwitchLib.Client/Events/OnVIPsReceivedArgs.cs
+++ b/TwitchLib.Client/Events/OnVIPsReceivedArgs.cs
@@ -18,6 +18,6 @@ namespace TwitchLib.Client.Events
         /// <summary>
         /// Property representing the list of VIPs.
         /// </summary>
-        public List<string> VIPs;
+        public string[] VIPs;
     }
 }

--- a/TwitchLib.Client/Extensions/EventInvocationExt.cs
+++ b/TwitchLib.Client/Extensions/EventInvocationExt.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Threading.Tasks;
 using TwitchLib.Client.Enums;
 using TwitchLib.Client.Events;
 using TwitchLib.Client.Models;
+using TwitchLib.Communication.Events;
 
 namespace TwitchLib.Client.Extensions
 {
@@ -12,7 +14,6 @@ namespace TwitchLib.Client.Extensions
     /// </summary>
     public static class EventInvocationExt
     {
-
         /// <summary>
         /// Invokes the channel state changed.
         /// </summary>
@@ -643,6 +644,14 @@ namespace TwitchLib.Client.Extensions
                 WhisperMessage = new WhisperMessage(badges, colorHex, color, username, displayName, emoteSet, threadId, messageId, userId, isTurbo, botUsername, message, userType)
             };
             client.RaiseEvent("OnWhisperReceived", model);
+        }
+
+        /// <summary>
+        /// Invokes the event handler when it is not null. Returns a completed task otherwise.
+        /// </summary>
+        internal static Task TryInvoke<TEventArgs>(this AsyncEventHandler<TEventArgs> eventHandler, object sender, TEventArgs eventArgs)
+        {
+            return eventHandler?.Invoke(sender, eventArgs) ?? Task.CompletedTask;
         }
     }
 }

--- a/TwitchLib.Client/Extensions/SplitExtensions.cs
+++ b/TwitchLib.Client/Extensions/SplitExtensions.cs
@@ -7,6 +7,19 @@ namespace TwitchLib.Client.Extensions
     internal static class SplitExtensions
     {
         /// <summary>
+        /// Splits the string into two parts at the first occurrence of a separator.
+        /// If the separator is not found, Segment will be the entire span and Remainder will be empty.
+        /// </summary>
+        /// <param name="source">Source span to split</param>
+        /// <param name="separator">Separator value</param>
+        /// <returns>A split pair of Segment and Remainder, deconstructible with tuple pattern.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ReadOnlySplitPair<char> SplitFirst(this string source, char separator)
+        {
+            return SplitFirst(source.AsSpan(), separator);
+        }
+
+        /// <summary>
         /// Splits the span into two parts at the first occurrence of a separator.
         /// If the separator is not found, Segment will be the entire span and Remainder will be empty.
         /// </summary>
@@ -26,7 +39,20 @@ namespace TwitchLib.Client.Extensions
         }
 
         /// <summary>
-        /// Splits the span into two parts at the first occurrence of a separator.
+        /// Splits the string into two parts at the last occurrence of a separator.
+        /// If the separator is not found, Segment will be the entire span and Remainder will be empty.
+        /// </summary>
+        /// <param name="source">Source span to split</param>
+        /// <param name="separator">Separator value</param>
+        /// <returns>A split pair of Segment and Remainder, deconstructible with tuple pattern.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ReadOnlySplitPair<char> SplitLast(this string source, char separator)
+        {
+            return SplitLast(source.AsSpan(), separator);
+        }
+
+        /// <summary>
+        /// Splits the span into two parts at the last occurrence of a separator.
         /// If the separator is not found, Segment will be the entire span and Remainder will be empty.
         /// </summary>
         /// <typeparam name="T">Span element type</typeparam>

--- a/TwitchLib.Client/Internal/Parsing/IrcParser.cs
+++ b/TwitchLib.Client/Internal/Parsing/IrcParser.cs
@@ -48,6 +48,7 @@ namespace TwitchLib.Client.Internal.Parsing
             {
                 return null;
             }
+            local = local.Slice(1);
 
             var tags = new Dictionary<string, string>();
 

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -1317,8 +1317,7 @@ namespace TwitchLib.Client
         {
             if (string.IsNullOrWhiteSpace(ircMessage.Message))
             {
-                return OnChatCleared?.Invoke(this, new() { Channel = ircMessage.Channel })
-                    ?? Task.CompletedTask;
+                return OnChatCleared.TryInvoke(this, new() { Channel = ircMessage.Channel });
             }
 
             var successBanDuration = ircMessage.Tags.TryGetValue(Tags.BanDuration, out _);
@@ -1536,7 +1535,7 @@ namespace TwitchLib.Client
 
             if (ircMessage.Message.StartsWith("-o"))
             {
-                return OnModeratorLeft.Invoke(this, new()
+                return OnModeratorLeft.TryInvoke(this, new()
                 {
                     Channel = ircMessage.Channel,
                     Username = ircMessage.Message.SplitFirst(' ').Remainder.ToString()

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -1124,13 +1124,13 @@ namespace TwitchLib.Client
         private Task HandleIrcMessageAsync(IrcMessage ircMessage)
         {
             var rawMessage = ircMessage.ToString();
-            if (rawMessage.StartsWith(":tmi.twitch.tv NOTICE * :Login authentication failed")
-                && OnIncorrectLogin != null)
-            {
-                return OnIncorrectLogin.Invoke(this, new()
+            if (rawMessage.StartsWith(":tmi.twitch.tv NOTICE * :Login authentication failed"))
+            { 
+                // Does this need to fallback to UnaccountedFor?
+                return OnIncorrectLogin?.Invoke(this, new()
                 {
                     Exception = new ErrorLoggingInException(rawMessage, TwitchUsername)
-                });
+                }) ?? Task.CompletedTask;
             }
 
             return ircMessage.Command switch


### PR DESCRIPTION
### Fixes
- Fix a bug in HandleNotice where `UnaccountedFor(...)` fallback was called even when `OnUnaccountedFor` event had a handler
- Fix comment on `IrcMessage` ctor
- Fix bug in `MesageEmoteCollection.Add(...)` which was indefinitely pattern + emoteText concatenating replacement regex until running out of maximum string length and crashing the application
- Fix usage of `SortedList` in `MessageEmoteCollection` - replaced with `Dictionary`
- Fix missed slicing in IrcParser to remove `@` at the start of tag sequence
- Fallback to unaccounted for on failed login if no failed login handler is registered (previously it would have been silently ignored)

### Cleanup
- Rewrite `HandleIrcMessageAsync` to use switch expression and forward the task
- Simplify and clean up `HandlePrivMsg`
- Rewrite `HandleNotice` to use switch expression and forward the task

### Performance
#### Environment
```
BenchmarkDotNet=v0.13.5, OS=macOS 14.0 [Darwin 23.0.0]
Apple M1 Pro, 1 CPU, 8 logical and 8 physical cores
.NET SDK=8.0.100-preview.7.23327.3
  [Host]   : .NET 7.0.1 (7.0.122.56804), Arm64 RyuJIT AdvSIMD
  ShortRun : .NET 7.0.1 (7.0.122.56804), Arm64 RyuJIT AdvSIMD

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  
```
#### Before
|               Method |     Mean |    Error |    StdDev |      Gen0 |      Gen1 |      Gen2 | Allocated |
|--------------------- |---------:|---------:|----------:|----------:|----------:|----------:|----------:|
| ClientScenarioCreate | 2.172 ms | 5.363 ms | 0.2940 ms | 1661.1328 | 1656.2500 | 1655.2734 |  24.59 MB |

#### After  (400x faster*)
|               Method |     Mean |     Error |    StdDev |   Gen0 |   Gen1 | Allocated |
|--------------------- |---------:|----------:|----------:|-------:|-------:|----------:|
| ClientScenarioCreate | 5.381 us | 0.2274 us | 0.0125 us | 3.2730 | 0.1144 |  20.06 KB |

*this is illustrative of any moderately long running application which keeps the same instance of `TwitchClient` (and `_channelEmotes`). I have no idea if there have been any complaints but there is no way this was working as intended previously without crashing applications the moment they connect to a big streamer chat stream or if they are just kept running for some time.

Closes #231 