### PR TITLE
faster/efficient `EmoteExtractor` and `Helpers`

### DIFF
--- a/TwitchLib.Client.Models/Common/Helpers.cs
+++ b/TwitchLib.Client.Models/Common/Helpers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using TwitchLib.Client.Models.Extensions;
 
 namespace TwitchLib.Client.Models.Common
 {
@@ -62,21 +63,14 @@ namespace TwitchLib.Client.Models.Common
 
             if (badgesStr.Contains('/'))
             {
-                if (!badgesStr.Contains(","))
+                foreach (var badge in new SpanSliceEnumerator(badgesStr, ','))
                 {
-                    var splitData = badgesStr.Split('/');
-                    badges.Add(new KeyValuePair<string, string>(splitData[0], splitData[1]));
-                }
-                else
-                {
-                    foreach (var badge in badgesStr.Split(','))
-                    {
-                        var splitData = badge.Split('/');
-                        badges.Add(new KeyValuePair<string, string>(splitData[0], splitData[1]));
-                    }
+                    var index = badge.IndexOf('/');
+                    var key = badge.Slice(0, index).ToString();
+                    var value = badge.Slice(index + 1).ToString();
+                    badges.Add(new KeyValuePair<string, string>(key, value));
                 }
             }
-
             return badges;
         }
 

--- a/TwitchLib.Client.Models/EmoteSet.cs
+++ b/TwitchLib.Client.Models/EmoteSet.cs
@@ -22,7 +22,7 @@ namespace TwitchLib.Client.Models
         {
             // this should be removed and used outside of object
             RawEmoteSetString = rawEmoteSetString;
-            Emotes = EmoteExtractor.Extract(rawEmoteSetString, message).ToList();
+            Emotes = EmoteExtractor.Extract(rawEmoteSetString, message);
         }
 
         /// <summary>Constructor for ChatEmoteSet object.</summary>

--- a/TwitchLib.Client.Models/Extensions/SpanSliceEnumerator.cs
+++ b/TwitchLib.Client.Models/Extensions/SpanSliceEnumerator.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace TwitchLib.Client.Models.Extensions;
+
+internal ref struct SpanSliceEnumerator
+{
+    ReadOnlySpan<char> _span;
+    readonly char _char;
+
+    public SpanSliceEnumerator(ReadOnlySpan<char> span, char @char)
+    {
+        _span = span;
+        _char = @char;
+    }
+
+    public SpanSliceEnumerator(string str, char @char) : this(str.AsSpan(), @char)
+    { }
+
+    public ReadOnlySpan<char> Current { get; private set; }
+
+    public SpanSliceEnumerator GetEnumerator() => this;
+
+    public bool MoveNext()
+    {
+        if (_span.IsEmpty)
+            return false;
+        var index = _span.IndexOf(_char);
+
+        if (index == -1)
+        {
+            Current = _span;
+            _span = default;
+        }
+        else
+        {
+            Current = _span.Slice(0, index);
+            _span = _span.Slice(index + 1);
+        }
+        return true;
+    }
+}

--- a/TwitchLib.Client.Models/TwitchLib.Client.Models.csproj
+++ b/TwitchLib.Client.Models/TwitchLib.Client.Models.csproj
@@ -31,4 +31,7 @@
     <_Parameter1>TwitchLib.Client</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
# Benchmarks
## Helpers.ParseBadges
Before:
| Method |               badges |     Mean |   Error |  StdDev |   Gen0 | Allocated |
|------- |--------------------- |---------:|--------:|--------:|-------:|----------:|
|    One |        subscriber/12 | 101.9 ns | 1.97 ns | 2.89 ns | 0.0484 |     304 B |
|    Two| subsc(...)ter/1 [27] | 188.6 ns | 2.58 ns | 3.86 ns | 0.0980 |     616 B |
|  theree | subsc(...)rbo/1 [35] | 235.9 ns | 2.42 ns | 3.47 ns | 0.1259 |     792 B |
|   Four| subsc(...)dsa/1 [47] | 293.8 ns | 3.04 ns | 4.55 ns | 0.1564 |     984 B |

After:
| Method |               badges |      Mean |    Error |   StdDev |   Gen0 | Allocated |
|------- |--------------------- |----------:|---------:|---------:|-------:|----------:|
|    One |        subscriber/12 |  87.95 ns | 2.353 ns | 3.299 ns | 0.0370 |     232 B |
|    Two| subsc(...)ter/1 [27] | 121.25 ns | 1.150 ns | 1.650 ns | 0.0484 |     304 B |
| theree| subsc(...)rbo/1 [35] | 161.52 ns | 2.241 ns | 3.285 ns | 0.0572 |     360 B |
|    Four | subsc(...)dsa/1 [47] | 190.27 ns | 2.767 ns | 4.056 ns | 0.0675 |     424 B |


## EmoteExtractor 
Before:
|         Method |           emoteSetStr |              message |       Mean |   Error |   StdDev |   Gen0 |   Gen1 | Allocated |
|--------------- |--------------------- |--------------------- |-----------:|--------:|---------:|-------:|-------:|----------:|
| MultipleEmotes | 25:0-(...)82-92 [65] | Kappa(...)heese [93] | 1,195.6 ns | 9.91 ns | 14.83 ns | 0.6771 | 0.0038 |    4248 B |
|       OneEmote |             25:25-29 | Twitc(...)Kappa [30] |   204.8 ns | 6.15 ns |  8.82 ns | 0.1159 |      - |     728 B |

After:
|         Method |           emoteSetStr |              message |     Mean |   Error |  StdDev |   Gen0 |   Gen1 | Allocated |
|--------------- |--------------------- |--------------------- |---------:|--------:|--------:|-------:|-------:|----------:|
| MultipleEmotes | 25:0-(...)82-92 [65] | Kappa(...)heese [93] | 650.9 ns | 5.92 ns | 7.91 ns | 0.3595 | 0.0019 |    2256 B |
|       OneEmote |             25:25-29 | Twitc(...)Kappa [30] | 111.7 ns | 1.28 ns | 1.87 ns | 0.0612 |      - |     384 B |