### PR TITLE
Make sure IrcMessage.Tags is never null and devirtualize the dictionary because it is used in hot paths

### DIFF
--- a/TwitchLib.Client.Models/Internal/IrcMessage.cs
+++ b/TwitchLib.Client.Models/Internal/IrcMessage.cs
@@ -45,7 +45,7 @@ namespace TwitchLib.Client.Models.Internal
         /// <summary>
         /// IRCv3 tags
         /// </summary>
-        public readonly IReadOnlyDictionary<string, string> Tags;
+        public readonly Dictionary<string, string> Tags;
 
         private string _rawString;
 
@@ -59,7 +59,7 @@ namespace TwitchLib.Client.Models.Internal
             User = user;
             Hostmask = null;
             Command = IrcCommand.Unknown;
-            Tags = null;
+            Tags = new Dictionary<string, string>();
         }
 
         /// <summary>
@@ -78,10 +78,10 @@ namespace TwitchLib.Client.Models.Internal
             var idx = hostmask.IndexOf('!');
             User = idx >= 0 ? hostmask.Substring(0, idx) : hostmask;
             Hostmask = hostmask;
-            _parameters = parameters;
             Command = command;
-            Tags = tags;
+            Tags = tags ?? new Dictionary<string, string>();
 
+            _parameters = parameters;
             if (command == IrcCommand.RPL_353
                 && Params.Length > 0
                 && Params.Contains("#"))
@@ -112,7 +112,7 @@ namespace TwitchLib.Client.Models.Internal
             User = user;
             Hostmask = hostmask;
             Command = command;
-            Tags = tags;
+            Tags = tags ?? new Dictionary<string, string>();
 
             _rawString = raw;
             _parameters = parameters;

--- a/TwitchLib.Client.Test/TwitchClientEventTests.cs
+++ b/TwitchLib.Client.Test/TwitchClientEventTests.cs
@@ -197,7 +197,8 @@ namespace TwitchLib.Client.Test
 
         private async Task ReceivedTestMessage()
         {
-            await _mockClient.ReceiveMessage($"@badges=subscriber/0,premium/1;color=#005C0B;display-name=KIJUI;emotes=30259:0-6;id=fefffeeb-1e87-4adf-9912-ca371a18cbfd;mod=0;room-id=22510310;subscriber=1;tmi-sent-ts=1530128909202;turbo=0;user-id=25517628;user-type= :kijui!kijui@kijui.tmi.twitch.tv PRIVMSG #testchannel :TEST MESSAGE");
+            await _mockClient.ReceiveMessage("@badges=subscriber/0,premium/1;color=#005C0B;display-name=KIJUI;emotes=30259:0-6;id=fefffeeb-1e87-4adf-9912-ca371a18cbfd;mod=0;room-id=22510310;subscriber=1;tmi-sent-ts=1530128909202;turbo=0;user-id=25517628;user-type= :kijui!kijui@kijui.tmi.twitch.tv PRIVMSG #testchannel :TEST MESSAGE");
+            // await _mockClient.ReceiveMessage(":jtv!jtv@jtv.tmi.twitch.tv PRIVMSG (HOSTED):(HOSTER) is now hosting you for (VIEWERS_TOTAL) viewers.");
         }
 
         private async Task ReceivedTwitchConnected()


### PR DESCRIPTION
Fixes NREs thrown around ChatMessage ctor and message handlers. This was not commonly hit previously because IrcParser used to always set the dictionary even if the message did not have any tags, despite the fact that IrcMessage's constructors exposed `tags` as optional argument that defaults to null - fix that by doing `??= new Dict...` because all code in TwitchLib assumes that the tags are never null.