### PR TITLE
Fix _client_OnMessage handling

### DIFF
--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -965,7 +965,7 @@ namespace TwitchLib.Client
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="OnMessageEventArgs" /> instance containing the event data.</param>
-        private Task _client_OnMessage(object sender, OnMessageEventArgs e)
+        private async Task _client_OnMessage(object sender, OnMessageEventArgs e)
         {
             var lines = e.Message.Split(NewLineSeparator, StringSplitOptions.None);
             foreach (var line in lines)
@@ -975,11 +975,9 @@ namespace TwitchLib.Client
 
                 _logger?.LogReceived(line);
 
-                _ = OnSendReceiveData?.TryInvoke(this, new() { Direction = SendReceiveDirection.Received, Data = line });
-                _ = HandleIrcMessageAsync(IrcParser.ParseMessage(line));
+                await OnSendReceiveData.TryInvoke(this, new() { Direction = SendReceiveDirection.Received, Data = line });
+                await HandleIrcMessageAsync(IrcParser.ParseMessage(line));
             }
-
-            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -976,7 +976,7 @@ namespace TwitchLib.Client
                 _logger?.LogReceived(line);
 
                 _ = OnSendReceiveData?.TryInvoke(this, new() { Direction = SendReceiveDirection.Received, Data = line });
-                return HandleIrcMessageAsync(IrcParser.ParseMessage(line));
+                _ = HandleIrcMessageAsync(IrcParser.ParseMessage(line));
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
- Don't return on the first line, process all lines
~~- Queue event handling concurrently (the sync part will run inline until the first yield)~~ Will refactor to channels in a separate PR.

Whoops, sorry.