### PR TITLE
MessageEmote: fixes emote replaced string with a hack until this can be re-written to something more sane, adds support for 7tv emotes

### DIFF
--- a/TwitchLib.Client.Models/MessageEmote.cs
+++ b/TwitchLib.Client.Models/MessageEmote.cs
@@ -235,7 +235,7 @@ namespace TwitchLib.Client.Models
     public class MessageEmoteCollection
     {
         private readonly Dictionary<string, MessageEmote> _emotes;
-        private const string BasePattern = @"(\b{0} \b)|(?<=\W){0}(?=$)|(?<=\s){0}(?=\s)";
+        private const string BasePattern = @"(\b {0}\b)|(\b{0} \b)|(?<=\W){0}(?=$)|(?<=\s){0}(?=\s)|(^{0}$)";
 
         /// <summary> Do not access directly! Backing field for <see cref="CurrentPattern"/> </summary>
         private string _currentPattern;


### PR DESCRIPTION
#### Changes
- adds support for 7tv emotes (joins bttv and ffz)
- adds a hack that fixes the emote replaced string that's been broken for like 5 years
 - this was originally referenced in #21 . the codebase for this feature is actually... quite complex. this hack changes the generated regex match string to require either space on one side or both sides, which is effectively the rules Twitch uses



#### Emote replaced string test cases
- LUL DansGame "LUL"
```
https://static-cdn.jtvnw.net/emoticons/v1/425618/1.0 https://static-cdn.jtvnw.net/emoticons/v1/33/1.0 "LUL"
```

- LUL DansGame "LUL" LUL LUL "LUL" "DansGame" WutFace "WutFace" MrDestructoid MrDestructoid
```
https://static-cdn.jtvnw.net/emoticons/v1/425618/1.0 https://static-cdn.jtvnw.net/emoticons/v1/33/1.0 "LUL" https://static-cdn.jtvnw.net/emoticons/v1/425618/1.0 https://static-cdn.jtvnw.net/emoticons/v1/425618/1.0  "LUL" "DansGame" https://static-cdn.jtvnw.net/emoticons/v1/28087/1.0  "WutFace" https://static-cdn.jtvnw.net/emoticons/v1/28/1.0  https://static-cdn.jtvnw.net/emoticons/v1/28/1.0 
```

- LUL
```
https://static-cdn.jtvnw.net/emoticons/v1/425618/1.0
```