### PR TITLE
IrcParser: make public and speed up by another <=15%

### DIFF
--- a/TwitchLib.Client.Benchmark/ChatMessage.cs
+++ b/TwitchLib.Client.Benchmark/ChatMessage.cs
@@ -1,5 +1,5 @@
 using BenchmarkDotNet.Attributes;
-using TwitchLib.Client.Internal.Parsing;
+using TwitchLib.Client.Parsing;
 using TwitchLib.Client.Models;
 using TwitchLib.Client.Models.Internal;
 

--- a/TwitchLib.Client.Benchmark/IrcMessageHandler.cs
+++ b/TwitchLib.Client.Benchmark/IrcMessageHandler.cs
@@ -1,5 +1,5 @@
 using BenchmarkDotNet.Attributes;
-using TwitchLib.Client.Internal.Parsing;
+using TwitchLib.Client.Parsing;
 
 namespace TwitchLib.Client.Benchmark
 {

--- a/TwitchLib.Client.Benchmark/IrcParser.cs
+++ b/TwitchLib.Client.Benchmark/IrcParser.cs
@@ -1,5 +1,5 @@
 using BenchmarkDotNet.Attributes;
-using TwitchLib.Client.Internal.Parsing;
+using TwitchLib.Client.Parsing;
 using TwitchLib.Client.Models.Internal;
 
 namespace TwitchLib.Client.Benchmark

--- a/TwitchLib.Client.Benchmark/TwitchLib.Client.Benchmark.csproj
+++ b/TwitchLib.Client.Benchmark/TwitchLib.Client.Benchmark.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TwitchLib.Client.Models/Internal/IrcMessage.cs
+++ b/TwitchLib.Client.Models/Internal/IrcMessage.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Text;
+﻿using System.Text;
 
 using TwitchLib.Client.Enums.Internal;
 
@@ -30,22 +29,22 @@ namespace TwitchLib.Client.Models.Internal
         /// <summary>
         /// The user whose message it is
         /// </summary>
-        public readonly string User;
+        public string User { get; }
 
         /// <summary>
         /// Hostmask of the user
         /// </summary>
-        public readonly string Hostmask;
+        public string Hostmask { get; }
 
         /// <summary>
         /// Raw Command
         /// </summary>
-        public readonly IrcCommand Command;
+        public IrcCommand Command { get; }
 
         /// <summary>
         /// IRCv3 tags
         /// </summary>
-        public readonly Dictionary<string, string> Tags;
+        public Dictionary<string, string> Tags { get; }
 
         private string _rawString;
 

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -8,7 +8,7 @@ using TwitchLib.Client.Exceptions;
 using TwitchLib.Client.Extensions;
 using TwitchLib.Client.Interfaces;
 using TwitchLib.Client.Internal;
-using TwitchLib.Client.Internal.Parsing;
+using TwitchLib.Client.Parsing;
 using TwitchLib.Client.Manager;
 using TwitchLib.Client.Models;
 using TwitchLib.Client.Models.Interfaces;


### PR DESCRIPTION
Supersedes #217

### Description
We can now make `IrcParser` public and it will do the right thing (tm) when utilized from user code.

- Add missing doc comments
- Add null/short string guard
- Improve parser perf. by another up to 15% depending on runtime by improving SplitFirst/Last logic (adopting learnings from working on another project)

To be honest, it is pretty meaningless to continue improving parsing performance since `TwitchLib` impl. is now faster than *popular* alternatives in Java, Rust and Go (some of them kind of shoot themselves in the foot though). But hey, neuron activation.

### Numbers
(before version supposedly roll-forwarded to a newer compiler version too so runtime perf. differences should not be significant)
Before:
```
BenchmarkDotNet=v0.13.5, OS=macOS 14.0 [Darwin 23.0.0]
Apple M1 Pro, 1 CPU, 8 logical and 8 physical cores
.NET SDK=8.0.100-preview.6.23316.13
  [Host]     : .NET 7.0.1 (7.0.122.56804), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 7.0.1 (7.0.122.56804), Arm64 RyuJIT AdvSIMD
```
| Method |              Message |      Mean |    Error |   StdDev |   Gen0 |   Gen1 | Allocated |
|------- |--------------------- |----------:|---------:|---------:|-------:|-------:|----------:|
|  Parse | :blub(...) list [66] |  76.47 ns | 0.191 ns | 0.178 ns | 0.0587 |      - |     368 B |
|  Parse |  :jtv(...)ers. [100] |  76.21 ns | 0.227 ns | 0.201 ns | 0.0573 |      - |     360 B |
|  Parse |  @bad(...)senE [884] | 856.95 ns | 2.589 ns | 2.295 ns | 0.5836 | 0.0048 |    3664 B |
|  Parse |  @bad(...)Guys [382] | 739.43 ns | 1.645 ns | 1.458 ns | 0.4101 | 0.0010 |    2576 B |
|  Parse | @msg-(...)live. [74] | 122.61 ns | 0.380 ns | 0.355 ns | 0.0994 |      - |     624 B |
|  Parse |  @msg(...)ces. [110] | 127.62 ns | 0.280 ns | 0.262 ns | 0.1109 |      - |     696 B |

After:
```
BenchmarkDotNet v0.13.7, macOS Sonoma 14.0 (23A5301h) [Darwin 23.0.0]
Apple M1 Pro, 1 CPU, 8 logical and 8 physical cores
.NET SDK 8.0.100-rc.1.23404.1
  [Host]     : .NET 8.0.0 (8.0.23.38103), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 8.0.0 (8.0.23.38103), Arm64 RyuJIT AdvSIMD
```
| Method |              Message |      Mean |    Error |   StdDev |   Gen0 |   Gen1 | Allocated |
|------- |--------------------- |----------:|---------:|---------:|-------:|-------:|----------:|
|  Parse | :blub(...) list [66] |  75.10 ns | 0.233 ns | 0.194 ns | 0.0714 |      - |     448 B |
|  Parse |  :jtv(...)ers. [100] |  73.24 ns | 0.280 ns | 0.262 ns | 0.0701 |      - |     440 B |
|  Parse |  @bad(...)senE [884] | 696.84 ns | 1.085 ns | 0.962 ns | 0.5836 | 0.0038 |    3664 B |
|  Parse |  @bad(...)Guys [382] | 586.12 ns | 1.104 ns | 0.922 ns | 0.4101 | 0.0010 |    2576 B |
|  Parse | @msg-(...)live. [74] | 106.09 ns | 0.175 ns | 0.155 ns | 0.0994 | 0.0001 |     624 B |
|  Parse |  @msg(...)ces. [110] | 109.15 ns | 0.183 ns | 0.163 ns | 0.1109 |      - |     696 B |