### PR TITLE
Updated ConnectionCredentials to use an anonymous user by default

### DIFF
--- a/TwitchLib.Client.Models/ConnectionCredentials.cs
+++ b/TwitchLib.Client.Models/ConnectionCredentials.cs
@@ -35,7 +35,7 @@ namespace TwitchLib.Client.Models
                 throw new Exception($"Twitch username does not appear to be valid. {twitchUsername}");
             }
 
-            TwitchUsername = twitchUsername?.ToLower() ?? $"justinfan${1000 + new Random().Next(79999)}";
+            TwitchUsername = twitchUsername?.ToLower() ?? $"justinfan{new Random().Next(1000, 89999)}";
             TwitchOAuth = twitchOAuth ?? string.Empty;
 
             // Make sure proper formatting is applied to oauth

--- a/TwitchLib.Client.Models/ConnectionCredentials.cs
+++ b/TwitchLib.Client.Models/ConnectionCredentials.cs
@@ -23,21 +23,25 @@ namespace TwitchLib.Client.Models
 
         /// <summary>Constructor for ConnectionCredentials object.</summary>
         public ConnectionCredentials(
-            string twitchUsername,
-            string twitchOAuth,
+            string? twitchUsername = null,
+            string? twitchOAuth = null,
             bool disableUsernameCheck = false,
             Capabilities? capabilities = null)
         {
-            if (!disableUsernameCheck && !GetUsernameCheckRegex().Match(twitchUsername).Success)
+            if (twitchUsername != null &&
+                !disableUsernameCheck &&
+                !GetUsernameCheckRegex().Match(twitchUsername).Success)
+            {
                 throw new Exception($"Twitch username does not appear to be valid. {twitchUsername}");
+            }
 
-            TwitchUsername = twitchUsername.ToLower();
-            TwitchOAuth = twitchOAuth;
+            TwitchUsername = twitchUsername?.ToLower() ?? $"justinfan${1000 + new Random().Next(79999)}";
+            TwitchOAuth = twitchOAuth ?? string.Empty;
 
             // Make sure proper formatting is applied to oauth
-            if (!twitchOAuth.Contains(":"))
+            if (!TwitchOAuth.Contains(":"))
             {
-                TwitchOAuth = $"oauth:{twitchOAuth.Replace("oauth", "")}";
+                TwitchOAuth = $"oauth:{TwitchOAuth.Replace("oauth", "")}";
             }
 
             Capabilities = capabilities ?? new Capabilities();


### PR DESCRIPTION
If no username is provided to the ConnectionCredentials, a default username of `justinfan` right-padded with 4-5 random digits will be generated which will allow an anonymous connection to twitch.

This follows the same logic used by [tmi.js](https://github.com/tmijs/tmi.js/blob/main/lib/utils.js#L27).