### PR TITLE
fix disconnect event type in TwitchClient

### DIFF
--- a/TwitchLib.Client.Test/TwitchClientEventTests.cs
+++ b/TwitchLib.Client.Test/TwitchClientEventTests.cs
@@ -141,7 +141,7 @@ namespace TwitchLib.Client.Test
         {
             var client = new TwitchClient(_mockClient);
 
-            await MyAssert.RaisesAsync<OnDisconnectedEventArgs>(
+            await MyAssert.RaisesAsync<OnDisconnectedArgs>(
                   h => client.OnDisconnected += h,
                   h => client.OnDisconnected -= h,
                   async () =>

--- a/TwitchLib.Client/Interfaces/ITwitchClient.cs
+++ b/TwitchLib.Client/Interfaces/ITwitchClient.cs
@@ -156,7 +156,7 @@ namespace TwitchLib.Client.Interfaces
         /// <summary>
         /// Fires when bot has disconnected.
         /// </summary>
-        event AsyncEventHandler<OnDisconnectedEventArgs>? OnDisconnected;
+        event AsyncEventHandler<OnDisconnectedArgs>? OnDisconnected;
 
         /// <summary>
         /// Forces when bot suffers connection error.

--- a/TwitchLib.Client/TwitchClient.cs
+++ b/TwitchLib.Client/TwitchClient.cs
@@ -196,7 +196,7 @@ namespace TwitchLib.Client
         public event AsyncEventHandler<OnUserLeftArgs>? OnUserLeft;
 
         /// <inheritdoc/>
-        public event AsyncEventHandler<OnDisconnectedEventArgs>? OnDisconnected;
+        public event AsyncEventHandler<OnDisconnectedArgs>? OnDisconnected;
 
         /// <inheritdoc/>
         public event AsyncEventHandler<OnConnectionErrorArgs>? OnConnectionError;
@@ -652,7 +652,7 @@ namespace TwitchLib.Client
         /// <param name="e">The <see cref="OnDisconnectedEventArgs" /> instance containing the event data.</param>
         private Task _client_OnDisconnected(object? sender, OnDisconnectedEventArgs e)
         {
-            return OnDisconnected.TryInvoke(sender, e);
+            return OnDisconnected.TryInvoke(sender, new(TwitchUsername));
         }
 
         /// <summary>


### PR DESCRIPTION
fixing an old typo (from V3) where someone accidentally used OnDisconnected event from `Communication`