### PR TITLE
adds MsgParamOriginId to GiftedSubscription model

### DIFF
--- a/TwitchLib.Client.Models/GiftedSubscription.cs
+++ b/TwitchLib.Client.Models/GiftedSubscription.cs
@@ -18,6 +18,11 @@ public class GiftedSubscription : UserNoticeBase
     public string MsgParamMonths { get; protected set; } = default!;
 
     /// <summary>
+    /// If this message sourced from an event, this is the ID of that event
+    /// </summary>
+    public string MsgParamOriginId { get; protected set; }
+
+    /// <summary>
     /// The display name of the subscription gift recipient.
     /// </summary>
     public string MsgParamRecipientDisplayName { get; protected set; } = default!;
@@ -78,13 +83,18 @@ public class GiftedSubscription : UserNoticeBase
         Dictionary<string, string>? undocumentedTags,
         Goal? msgParamGoal,
         string msgParamMonths,
+        string msgParamOriginId,
         string msgParamRecipientDisplayName,
         string msgParamRecipientId,
         string msgParamRecipientUserName, 
         int msgParamSenderCount, 
         SubscriptionPlan msgParamSubPlan, 
         string msgParamSubPlanName, 
-        int msgParamMultiMonthGiftDuration)
+        int msgParamMultiMonthGiftDuration,
+        string msgParamGoalContributionType,
+        int msgParamGoalCurrentContributions,
+        int msgParamGoalTargetContributions,
+        int msgParamGoalUserContributions)
        : base(badgeInfo,
            badges,
            hexColor,
@@ -104,6 +114,7 @@ public class GiftedSubscription : UserNoticeBase
         MsgParamGoal = msgParamGoal;
         IsAnonymous = userId == AnonymousGifterUserId;
         MsgParamMonths = msgParamMonths;
+        MsgParamOriginId = msgParamOriginId;
         MsgParamRecipientDisplayName = msgParamRecipientDisplayName;
         MsgParamRecipientId = msgParamRecipientId;
         MsgParamRecipientUserName = msgParamRecipientUserName;
@@ -120,6 +131,9 @@ public class GiftedSubscription : UserNoticeBase
         {
             case Tags.MsgParamMonths:
                 MsgParamMonths = tag.Value;
+                break;
+            case Tags.MsgParamOriginId:
+                MsgParamOriginId = tag.Value;
                 break;
             case Tags.MsgParamRecipientDisplayName:
                 MsgParamRecipientDisplayName = tag.Value;

--- a/TwitchLib.Client.Models/GiftedSubscription.cs
+++ b/TwitchLib.Client.Models/GiftedSubscription.cs
@@ -90,11 +90,7 @@ public class GiftedSubscription : UserNoticeBase
         int msgParamSenderCount, 
         SubscriptionPlan msgParamSubPlan, 
         string msgParamSubPlanName, 
-        int msgParamMultiMonthGiftDuration,
-        string msgParamGoalContributionType,
-        int msgParamGoalCurrentContributions,
-        int msgParamGoalTargetContributions,
-        int msgParamGoalUserContributions)
+        int msgParamMultiMonthGiftDuration)
        : base(badgeInfo,
            badges,
            hexColor,

--- a/TwitchLib.Client.Models/Internal/Tags.cs
+++ b/TwitchLib.Client.Models/Internal/Tags.cs
@@ -47,6 +47,7 @@ namespace TwitchLib.Client.Models.Internal
         public const string MsgParamSubPlan = "msg-param-sub-plan";                             // Sent only on sub, resub, subgift, anonsubgift
         public const string MsgParamSubPlanName = "msg-param-sub-plan-name";                    // Sent only on sub, resub, subgift, anonsubgift
         public const string MsgParamViewerCount = "msg-param-viewerCount";                      // Sent only on raid
+        public const string MsgParamOriginId = "msg-param-origin-id";
         public const string MsgParamRecipientDisplayName = "msg-param-recipient-display-name";  // Sent only on subgift, anonsubgift
         public const string MsgParamRecipientId = "msg-param-recipient-id";                     // Sent only on subgift, anonsubgift
         public const string MsgParamRecipientUsername = "msg-param-recipient-user-name";        // Sent only on subgift, anonsubgift


### PR DESCRIPTION
This PR adds support for MsgParamOriginId to the GiftedSubscription model. 

`
@badge-info=founder/122;badges=staff/1,moderator/1,founder/0,sub-gifter/300;color=#FF3AE9;display-name=swiftyspiffy;emotes=;flags=;id=26dd4088-9efb-49bf-8fcc-32d04d530bd3;login=swiftyspiffy;mod=1;msg-id=subgift;msg-param-gift-months=1;msg-param-goal-contribution-type=SUB_POINTS;msg-param-goal-current-contributions=2749;msg-param-goal-target-contributions=2600;msg-param-goal-user-contributions=1;msg-param-months=78;msg-param-origin-id=17946483715777061145;msg-param-recipient-display-name=BleuBelladonna;msg-param-recipient-id=75543494;msg-param-recipient-user-name=bleubelladonna;msg-param-sender-count=310;msg-param-sub-plan-name=The\sPirate's\sSubscription;msg-param-sub-plan=1000;room-id=44338537;subscriber=1;system-msg=swiftyspiffy\sgifted\sa\sTier\s1\ssub\sto\sBleuBelladonna!\sThey\shave\sgiven\s310\sGift\sSubs\sin\sthe\schannel!;tmi-sent-ts=1725613193963;user-id=40876073;user-type=staff;vip=0 :tmi.twitch.tv USERNOTICE #burkeblack
`

For the `subgift` this is the only indicator of a gifted sub being part of a bulk gift sub event. So, devs can use this parameter to avoid spamming chat with a message for each individual user receiving a gifted sub.